### PR TITLE
Add spec for team CRUD endpoint

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -87,7 +87,7 @@ x-resources:
       "Shapes are vectors that each user can create and manage. These shapes can then be used in various ways within the Raster Foundry platform."
   - name: Licenses
     description: |
-      "A license is an official permission or permit to do, use, or own something."
+      "A license is an official permission or permit to do, use, or own something." Users can add licenses to the data they create and share in Raster Foundry to communicate to others if and how that data can be used.
   - name: Teams
     description: |
       "Teams represent groups of users within (and across) organizations. Each team belongs to one organization. A user can be a member of any number of teams."
@@ -491,10 +491,7 @@ paths:
         - Authentication
         - Imagery
       parameters:
-        - name: uuid
-          in: path
-          required: true
-          type: string
+        - $ref: '#/parameters/uuid'
       responses:
         200:
           description: AWS credentials scoped to the upload bucket with prefix
@@ -2061,7 +2058,7 @@ paths:
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Team'
+            $ref: '#/definitions/TeamCreate'
       responses:
         201:
           description: Get a newly created team
@@ -2077,7 +2074,7 @@ paths:
     get:
       summary: Get team details
       tags:
-        - User
+        - Users
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
@@ -2093,17 +2090,19 @@ paths:
     put:
       summary: Update a team
       tags:
-        - User
+        - Users
       parameters:
         - name: team
           in: body
           required: true
           schema:
-            $ref: '#/definitions/Team'
+            $ref: '#/definitions/TeamCreate'
         - $ref: '#/parameters/uuid'
       responses:
         204:
           description: Update successful (no further processing needed)
+          schema:
+            $ref: '#/definitions/Team'
         404:
           description: |
             UUID parameter does not refer to a team or the user is not able to view the team it refers to
@@ -2117,7 +2116,7 @@ paths:
       summary: Delete a team
       description: delete a team based on team id
       tags:
-        - User
+        - Users
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
@@ -2922,13 +2921,8 @@ definitions:
 
   Team:
     allOf:
-    - $ref: '#/definitions/TimeModelMixin'
     - type: object
       properties:
-        id:
-          type: string
-          format: UUID
-          description: Team ID
         createdBy:
           type: string
           description: User who created the object
@@ -2937,16 +2931,27 @@ definitions:
           type: string
           description: User who most recently modified the object
           readOnly: true
-        organizationId:
+        id:
           type: string
           format: UUID
-          description: uuid for organization
-        name:
-          type: string
-          description: name of a team
-        settings:
-          type: object
-          description: settings for a team, default to {}
+          description: Team ID
+    - $ref: '#/definitions/TimeModelMixin'
+    - $ref: '#/definitions/TeamCreate'
+
+
+  TeamCreate:
+    type: object
+    properties:
+      organizationId:
+        type: string
+        format: UUID
+        description: uuid for organization
+      name:
+        type: string
+        description: name of a team
+      settings:
+        type: object
+        description: settings for a team, default to {}
 
 
   Geometry:

--- a/spec.yml
+++ b/spec.yml
@@ -87,7 +87,7 @@ x-resources:
       "Shapes are vectors that each user can create and manage. These shapes can then be used in various ways within the Raster Foundry platform."
   - name: Licenses
     description: |
-      "A license is an official permission or permit to do, use, or own something." Users can add licenses to the data they create and share in Raster Foundry to communicate to others if and how that data can be used.
+      "A license is an official permission or permit to do, use, or own something. Users can add licenses to the data they create and share in Raster Foundry to communicate to others if and how that data can be used."
   - name: Teams
     description: |
       "Teams represent groups of users within (and across) organizations. Each team belongs to one organization. A user can be a member of any number of teams."

--- a/spec.yml
+++ b/spec.yml
@@ -85,6 +85,13 @@ x-resources:
   - name: Shapes
     description: |
       "Shapes are vectors that each user can create and manage. These shapes can then be used in various ways within the Raster Foundry platform."
+  - name: Licenses
+    description: |
+      "A license is an official permission or permit to do, use, or own something."
+  - name: Teams
+    description: |
+      "Teams represent groups of users within (and across) organizations. Each team belongs to one organization. A user can be a member of any number of teams."
+
 
 tags:
   - name: Users
@@ -2005,7 +2012,8 @@ paths:
     get:
       summary: Get a list of licenses
       tags:
-        - Licenses
+        - Imagery
+        - Lab
       parameters:
         - $ref: '#/parameters/pageSize'
         - $ref: '#/parameters/page'
@@ -2013,14 +2021,15 @@ paths:
         200:
           description: SUCCESS
           schema:
-            $ref: '#/definitions/LicensePaginated'
+            $ref: '#/definitions/LicensesPaginated'
 
   /licenses/{licenseId}:
     x-resource: Licenses
     get:
       summary: Get a license based on its id
       tags:
-        - Licenses
+        - Imagery
+        - Lab
       parameters:
         - $ref: '#/parameters/licenseId'
       responses:
@@ -2028,6 +2037,97 @@ paths:
           description: SUCCESS
           schema:
             $ref: '#/definitions/License'
+
+  /teams/:
+    x-resource: Teams
+    get:
+      summary: Get a list of teams
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/parameters/pageSize'
+        - $ref: '#/parameters/page'
+      responses:
+        200:
+          description: SUCCESS
+          schema:
+            $ref: '#/definitions/TeamsPaginated'
+    post:
+      summary: Create a team
+      tags:
+        - Users
+      parameters:
+        - name: team
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Team'
+      responses:
+        201:
+          description: Get a newly created team
+          schema:
+            $ref: '#/definitions/Team'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+
+  /teams/{uuid}:
+    x-resource: Teams
+    get:
+      summary: Get team details
+      tags:
+        - User
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        200:
+          description: Detail about a team
+          schema:
+            $ref: '#/definitions/Team'
+        404:
+          description: |
+            UUID parameter does not refer to a team or the user is not able to view the team it refers to
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: Update a team
+      tags:
+        - User
+      parameters:
+        - name: team
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/Team'
+        - $ref: '#/parameters/uuid'
+      responses:
+        204:
+          description: Update successful (no further processing needed)
+        404:
+          description: |
+            UUID parameter does not refer to a team or the user is not able to view the team it refers to
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete a team
+      description: delete a team based on team id
+      tags:
+        - User
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        204:
+          description: Deletion successful (no content)
+        404:
+          description: |
+            UUID parameter does not refer to a team or the user is not able to view the team it refers to
+          schema:
+            $ref: '#/definitions/Error'
 
 
 parameters:
@@ -2809,6 +2909,46 @@ definitions:
       required:
         - name
         - id
+
+  TeamsPaginated:
+    allOf:
+    - $ref: '#/definitions/PaginatedResponse'
+    - type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/definitions/Team'
+
+  Team:
+    allOf:
+    - $ref: '#/definitions/TimeModelMixin'
+    - type: object
+      properties:
+        id:
+          type: string
+          format: UUID
+          description: Team ID
+        createdBy:
+          type: string
+          description: User who created the object
+          readOnly: true
+        modifiedBy:
+          type: string
+          description: User who most recently modified the object
+          readOnly: true
+        organizationId:
+          type: string
+          format: UUID
+          description: uuid for organization
+        name:
+          type: string
+          description: name of a team
+        settings:
+          type: object
+          description: settings for a team, default to {}
+
+
   Geometry:
       type: object
       description: GeoJSON geometry
@@ -2937,7 +3077,7 @@ definitions:
         type: string
         description: URL to details of a license
 
-  LicensePaginated:
+  LicensesPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
     - type: object


### PR DESCRIPTION
This PR adds spec for team CRUD endpoint implemented in https://github.com/raster-foundry/raster-foundry/pull/3127

**This is a part of `feature/platform-spec`**

Marked as WIP since there might be some clean up to do.

Closes #4 