### PR TITLE
Add shape id field in scene query

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -531,6 +531,11 @@ paths:
         - $ref: '#/parameters/ingested'
         - $ref: '#/parameters/ingestStatus'
         - $ref: '#/parameters/forProjectId'
+        - name: shape
+          in: query
+          type: string
+          format: uuid
+          description: UUID of a shape in shapes table
       responses:
         200:
           description: Paginated list of scenes


### PR DESCRIPTION
## Overview
This PR adds an optional shape id field in scene query that represents an UUID of a shape in the shapes table to be applied to filter scenes based on footprint.

## Notes
 * Swagger editor may say `Semantic error at paths./uploads/{uuid}/credentials/.get.parameters.0`, this is already fixed in PR https://github.com/raster-foundry/raster-foundry-api-spec/pull/6 and should not be an issue after that PR is merged
 * This spec may change based on this endpoint's implementation in https://github.com/raster-foundry/raster-foundry/pull/3142
