### PR TITLE
Add isActive to AOI definition

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -2500,6 +2500,8 @@ definitions:
         type: object
       filters:
         $ref: '#/definitions/CombinedSceneQueryParams'
+      isActive:
+        type: boolean
   ColorCorrection:
     type: object
     properties:


### PR DESCRIPTION
This PR adds the `isActive` parameter to the AOI definition