### PR TITLE
Move organizationId to teams

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -2540,9 +2540,6 @@ definitions:
         type: string
         description: unique identifier for object
         format: uuid
-      organizationId:
-        type: string
-        description: uuid for organization
   BaseCreate:
     type: object
     properties:
@@ -2592,9 +2589,6 @@ definitions:
   AOI:
     type: object
     properties:
-      organizationId:
-        type: string
-        format: uuid
       area:
         type: object
       filters:
@@ -2722,16 +2716,11 @@ definitions:
     - type: object
       required:
         - id
-        - organizationId
         - role
       properties:
         id:
           type: string
           description: User ID for Raster Foundry
-        organizationId:
-          type: string
-          format: uuid
-          description: UUID of organization to which user belongs
         role:
           type: string
           description: User role in organization
@@ -2828,10 +2817,6 @@ definitions:
       id:
         type: string
         description: Auth0 ID for user
-      organizationId:
-        type: string
-        format: uuid
-        description: UUID for organization that user is being created for
       role:
         type: string
         description: Role to create user with in the provided organization
@@ -2931,6 +2916,9 @@ definitions:
           type: string
           description: User who most recently modified the object
           readOnly: true
+        organizationId:
+          type: string
+          description: uuid for organization
         id:
           type: string
           format: UUID
@@ -3037,9 +3025,6 @@ definitions:
               - PUBLIC
               - ORGANIZATION
               - PRIVATE
-          organizationId:
-            type: string
-            description: uuid for organization
           name:
             type: string
             description: human label name for datasource


### PR DESCRIPTION
raster-foundry/raster-foundry#3378 purges `organizationId` relations from everywhere except `Team`s.
This PR does the same in the spec.