### PR TITLE
Add scene datasource endpoint

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -1168,6 +1168,23 @@ paths:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+  /scenes/{uuid}/datasource:
+    x-resource: Scenes
+    get:
+      summary: Get the datasource for a scene you can view
+    tags:
+      - Imagery
+    parameters:
+      - $ref: '#/parameters/uuid'
+    responses:
+      200:
+        description: A datasource
+        schema:
+          $ref: '#/definitions/Datasource'
+      403:
+        description: The scene does not exist or the requesting user cannot view it
+        schema:
+          $ref: '#/definitions/Error'
   /scene-grid/{zoom}/{column}/{row}/:
     x-resource: Scenes
     get:

--- a/spec.yml
+++ b/spec.yml
@@ -3883,6 +3883,18 @@ definitions:
       - $ref: '#/definitions/TimeModelMixin'
       - $ref: '#/definitions/DatasourceCreated'
 
+  DatasourceThin:
+    type: object
+    description: A datasource with a reduced set of fields
+    properties:
+      name:
+        type: string
+        description: The name of this datasource
+      id:
+        type: string
+        format: uuid
+        description: The id of this datasource
+
   DatasourcePaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -3955,9 +3967,10 @@ definitions:
             type: array
             items:
               $ref: '#/definitions/Thumbnail'
-          dataSource:
-            type: string
-            format: uuid
+          datasource:
+            type: object
+            schema:
+              $ref: '#/definitions/DatasourceThin'
             description: Data source scene originated from
           dataFootprint:
             $ref: '#/definitions/MultiPolygon'


### PR DESCRIPTION
This PR adds the scene datasource endpoint to the `/scenes/` section of the API spec.