### PR TITLE
Features/lk/update platform org user routes

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -192,6 +192,22 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+  /users/search/:
+    x-resource: Users
+    get:
+      summary: 'Search for users'
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/parameters/search'
+      responses:
+        200:
+          description: 'Up to 5 users matching search'
+          schema:
+            type: array
+            maxItems: 5
+            items:
+              $ref: '#/definitions/UserSearched'
   /users/{uuid}/:
     x-resource: Users
     get:
@@ -204,7 +220,7 @@ paths:
         200:
           description: 'User found'
           schema:
-            $ref: '#/definitions/User'
+            $ref: '#/definitions/UserSearched'
         404:
           description: 'User not found'
           schema:
@@ -214,7 +230,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: 'Update a user'
+      summary: 'Update a user. Dev use only'
       tags:
         - Users
       parameters:
@@ -227,6 +243,10 @@ paths:
       responses:
         204:
           description: 'Update successful (No Content)'
+        403:
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
         default:
           description: 'Unexpected error'
           schema:
@@ -265,6 +285,22 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+  /organizations/search/:
+    x-resource: Organizations
+    get:
+      summary: 'Search for organizations'
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/parameters/search'
+      responses:
+        200:
+          description: 'Up to 5 organizations matching search'
+          schema:
+            type: array
+            maxItems: 5
+            items:
+              $ref: '#/definitions/Organization'
   /organizations/{organizationID}/:
     x-resource: Organizations
     get:
@@ -413,7 +449,7 @@ paths:
   /platforms/{platformID}/members/:
     x-resource: Platforms
     get:
-      summary: 'Get a list of users for the platform'
+      summary: 'Get a list of users for the platform. Platform admin only'
       tags:
         - Platforms
       parameters:
@@ -455,7 +491,7 @@ paths:
   /platforms/{platformID}/organizations/:
     x-resource: Platforms
     get:
-      summary: 'List platform organizations that the user has permissions to view'
+      summary: 'List platform organizations. Platform admin only.'
       tags:
         - Platforms
       parameters:
@@ -558,7 +594,7 @@ paths:
   /platforms/{platformID}/organizations/{organizationID}/members/:
     x-resource: Platforms
     get:
-      summary: 'Fetch organization member list'
+      summary: 'Fetch organization member list. Organization admin only'
       tags:
         - Platforms
       parameters:
@@ -4030,7 +4066,7 @@ definitions:
         $ref: '#/definitions/Auth0User'
   UserWithRole:
     allOf:
-      - $ref: '#/definitions/User'
+      - $ref: '#/definitions/UserSearched'
       - type: object
         properties:
           groupRole:
@@ -4190,7 +4226,7 @@ definitions:
         results:
           type: array
           items:
-            $ref: '#/definitions/User'
+            $ref: '#/definitions/UserSearched'
   ScenePaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'

--- a/spec.yml
+++ b/spec.yml
@@ -54,18 +54,18 @@ x-resources:
         content: |
           Images respect the permissions applied to their parent scenes.
   - name: Uploads
-    description: Uploads are datasets that a user or application has attempted to upload to Raster Foundry (successfully or unsuccessfully).
+    description: 'Uploads are datasets that a user or application has attempted to upload to Raster Foundry (successfully or unsuccessfully).'
     further-description:
       - title: Uploads permissions
         content: |
           All user uploads are private to that user.
   - name: Datasources
     description: |
-      "Datasources contain information common to all scenes associated with them, such as the number of bands to expect in images associated with that datasource. A datasource can be specific (e.g. a particular earth observation satellite) or generic (e.g. a 3-band sensor on a UAV). All scenes must have an associated datasource."
+      Datasources contain information common to all scenes associated with them, such as the number of bands to expect in images associated with that datasource. A datasource can be specific (e.g. a particular earth observation satellite) or generic (e.g. a 3-band sensor on a UAV). All scenes must have an associated datasource.
 
-      "Currently, datasources cannot be created through the API and must be requested (<a href="https://github.com/azavea/raster-foundry/issues" target="_blank">preferably as a Github issue in the source repository</a>)."
+      Currently, datasources cannot be created through the API and must be requested (<a href="https://github.com/azavea/raster-foundry/issues" target="_blank">preferably as a Github issue in the source repository</a>).
 
-      "In the future, users will be able to manage the creation, amendment, and deletion of datasources directly through the API. Also, users will be able to assign transformations like color correction, band composites, or color maps to datasources as a default for themselves and/or their organizations."
+      In the future, users will be able to manage the creation, amendment, and deletion of datasources directly through the API. Also, users will be able to assign transformations like color correction, band composites, or color maps to datasources as a default for themselves and/or their organizations.
   - name: Tokens
     description: |
       Tokens are used to securely identify users and applications accessing the API.
@@ -84,34 +84,34 @@ x-resources:
       Projects can be exported, but individual scenes and images cannot.
   - name: Shapes
     description: |
-      "Shapes are vectors that each user can create and manage. These shapes can then be used in various ways within the Raster Foundry platform."
+      Shapes are vectors that each user can create and manage. These shapes can then be used in various ways within the Raster Foundry platform.
   - name: Licenses
     description: |
-      "A license is an official permission or permit to do, use, or own something. Users can add licenses to the data they create and share in Raster Foundry to communicate to others if and how that data can be used."
+      A license is an official permission or permit to do, use, or own something. Users can add licenses to the data they create and share in Raster Foundry to communicate to others if and how that data can be used.
   - name: Teams
     description: |
-      "Teams represent groups of users within (and across) organizations. Each team belongs to one organization. A user can be a member of any number of teams."
+      Teams represent groups of users within (and across) organizations. Each team belongs to one organization. A user can be a member of any number of teams.
 
 
 tags:
   - name: Users
-    description: Operations involving users and organizations
+    description: 'Operations involving users and organizations'
   - name: Authentication
-    description: Resources to obtain, use, and delete API tokens
+    description: 'Resources to obtain, use, and delete API tokens'
   - name: Imagery
-    description: Interact with imagery
+    description: 'Interact with imagery'
   - name: Lab
-    description: Geospatial processing discovery and endpoints
+    description: 'Geospatial processing discovery and endpoints'
   - name: Statistics
-    description: Statistical metadata about geospatial data
+    description: 'Statistical metadata about geospatial data'
   - name: Permissions
-    description: Resources relating to object-level access
+    description: 'Resources relating to object-level access'
 
 paths:
   /users/dropbox-setup/:
     x-resource: Users
     post:
-      summary: Store a dropbox access token for a user from an authorization code
+      summary: 'Store a dropbox access token for a user from an authorization code'
       tags:
         - Users
       parameters:
@@ -121,24 +121,24 @@ paths:
               $ref: '#/definitions/DropboxAuthRequest'
       responses:
         200:
-          description: Dropbox access token successfully fetched
+          description: 'Dropbox access token successfully fetched'
   /users/me/:
     x-resource: Users
     get:
-      summary: Get a logged-in user profile
+      summary: 'Get a logged-in user profile'
       tags:
         - Users
       responses:
         200:
-          description: Profile found
+          description: 'Profile found'
           schema:
             $ref: '#/definitions/UserWithOAuth'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     patch:
-      summary: Update user profile information
+      summary: 'Update user profile information'
       parameters:
         - name: Profile
           in: body
@@ -148,16 +148,15 @@ paths:
         - Users
       responses:
         200:
-          description: Profile updated
+          description: 'Profile updated'
           schema:
             $ref: '#/definitions/Auth0User'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary:
-        Update user api tokens
+      summary: 'Update user api tokens'
       tags:
         - Users
       parameters:
@@ -167,55 +166,55 @@ paths:
             $ref: '#/definitions/User'
       responses:
         204:
-          description: No Content
+          description: 'No Content'
         404:
-          description: User not found
+          description: 'User not found'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /users/me/roles:
     x-resource: Users
     get:
-      summary: Get a logged-in user''s roles
+      summary: "Get a logged-in user's roles"
       tags:
         - Users
       responses:
         200:
-          description: Roles found
+          description: 'Roles found'
           schema:
             type: array
             items:
               $ref: '#/definitions/UserGroupRole'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /users/{uuid}/:
     x-resource: Users
     get:
-      summary: Get a single user
+      summary: 'Get a single user'
       tags:
         - Users
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: User found
+          description: 'User found'
           schema:
             $ref: '#/definitions/User'
         404:
-          description: User not found
+          description: 'User not found'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update a user
+      summary: 'Update a user'
       tags:
         - Users
       parameters:
@@ -227,15 +226,15 @@ paths:
             $ref: '#/definitions/User'
       responses:
         204:
-          description: Update successful (No Content)
+          description: 'Update successful (No Content)'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /organizations/:
     x-resource: Organizations
     get:
-      summary: Get a list of organizations
+      summary: 'Get a list of organizations'
       tags:
         - Users
       parameters:
@@ -244,11 +243,11 @@ paths:
         - $ref: '#/parameters/page'
       responses:
         200:
-          description: Paginated list of organizations
+          description: 'Paginated list of organizations'
           schema:
             $ref: '#/definitions/OrganizationsPaginated'
     post:
-      summary: Create an organization
+      summary: 'Create an organization'
       tags:
         - Users
       parameters:
@@ -259,32 +258,32 @@ paths:
             $ref: '#/definitions/Organization'
       responses:
         201:
-          description: Get newly created organization
+          description: 'Get newly created organization'
           schema:
             $ref: '#/definitions/Organization'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /organizations/{organizationID}/:
     x-resource: Organizations
     get:
-      summary: Get details for an organization
+      summary: 'Get details for an organization'
       tags:
         - Users
       parameters:
         - $ref: '#/parameters/organizationID'
       responses:
         200:
-          description: Returned organization
+          description: 'Returned organization'
           schema:
             $ref: '#/definitions/Organization'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update an organization
+      summary: 'Update an organization'
       tags:
         - Users
       parameters:
@@ -296,33 +295,33 @@ paths:
             $ref: '#/definitions/Organization'
       responses:
         204:
-          description: Update successful (No Content)
+          description: 'Update successful (No Content)'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /organizations/{organizationID}/users/:
     x-resource: Organizations
     get:
-      summary: Get users and roles for an organization
+      summary: 'Get users and roles for an organization'
       tags:
         - Users
       parameters:
         - $ref: '#/parameters/organizationID'
       responses:
         200:
-          description: Paginated list of user roles
+          description: 'Paginated list of user roles'
           schema:
             $ref: '#/definitions/UserPaginated'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /platforms/:
     x-resource: Platforms
     get:
-      summary: Get a list of platforms
+      summary: 'Get a list of platforms'
       tags:
         - Platforms
       parameters:
@@ -330,15 +329,15 @@ paths:
         - $ref: '#/parameters/pageSize'
       responses:
         200:
-          description: Paginated list platforms
+          description: 'Paginated list platforms'
           schema:
             $ref: '#/definitions/PlatformsPaginated'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Create a platform
+      summary: 'Create a platform'
       tags:
         - Platforms
       parameters:
@@ -348,36 +347,36 @@ paths:
             $ref: '#/definitions/Platform'
       responses:
         201:
-          description: Platform created
+          description: 'Platform created'
           schema:
             $ref: '#/definitions/Platform'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/:
     x-resource: Platforms
     get:
-      summary: Get a platform
+      summary: 'Get a platform'
       tags:
         - Platforms
       parameters:
         - $ref: '#/parameters/platformID'
       responses: 
         200:
-          description: Platform found
+          description: 'Platform found'
           schema:
             $ref: '#/definitions/Platform'
         404:
-          description: Platform not found
+          description: 'Platform not found'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update a platform
+      summary: 'Update a platform'
       tags:
         - Platforms
       parameters:
@@ -388,24 +387,24 @@ paths:
             $ref: '#/definitions/Platform'
       responses:
         204:
-          description: No Content (Update successful)
+          description: 'No Content (Update successful)'
         404:
-          description: Platform not found
+          description: 'Platform not found'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected Error
+          description: 'Unexpected Error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete a platform
+      summary: 'Delete a platform'
       tags:
         - Platforms
       parameters:
         - $ref: '#/parameters/platformID'
       responses:
         204:
-          description: Deletion Successful (no content)
+          description: 'Deletion Successful (no content)'
         404:
           description: |
             The UUID parameter does not refer to platform or the user does not have permission to perform this action
@@ -414,7 +413,7 @@ paths:
   /platforms/{platformID}/members/:
     x-resource: Platforms
     get:
-      summary: Get a list of users for the platform
+      summary: 'Get a list of users for the platform'
       tags:
         - Platforms
       parameters:
@@ -424,15 +423,15 @@ paths:
         - $ref: '#/parameters/search'
       responses:
         200:
-          description: Paginated list of users with their platform role
+          description: 'Paginated list of users with their platform role'
           schema:
             $ref: '#/definitions/UserWithRolePaginated'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Move a user to the platform
+      summary: 'Move a user to the platform'
       tags:
         - Platforms
       parameters:
@@ -444,19 +443,19 @@ paths:
             $ref: '#/definitions/UserRole'
       responses:
         200:
-          description: List of modified user roles
+          description: 'List of modified user roles'
           schema:
             type: array
             items:
               $ref: '#/definitions/UserGroupRole'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/:
     x-resource: Platforms
     get:
-      summary: List platform organizations that the user has permissions to view
+      summary: 'List platform organizations that the user has permissions to view'
       tags:
         - Platforms
       parameters:
@@ -465,15 +464,15 @@ paths:
         - $ref: '#/parameters/pageSize'
       responses:
         200:
-          description: Paginated Organizations
+          description: 'Paginated Organizations'
           schema:
             $ref: '#/definitions/OrganizationsPaginated'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Create an Organization.
+      summary: 'Create an Organization.'
       tags:
         - Platforms
       parameters:
@@ -485,17 +484,17 @@ paths:
             $ref: '#/definitions/OrganizationCreate'
       responses:
         201:
-          description: Organization created
+          description: 'Organization created'
           schema:
             $ref: '#/definitions/Organization'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/:
     x-resource: Platforms
     get:
-      summary: Fetch platform organization
+      summary: 'Fetch platform organization'
       tags:
         - Platforms
       parameters:
@@ -503,19 +502,19 @@ paths:
         - $ref: '#/parameters/organizationID'
       responses:
         200:
-          description: Organization
+          description: 'Organization found'
           schema:
             $ref: '#/definitions/Organization'
         404:
-          description: Organization not found
+          description: 'Organization not found'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update platform organization
+      summary: 'Update platform organization'
       tags:
         - Platforms
       parameters:
@@ -528,17 +527,17 @@ paths:
             $ref: '#/definitions/Organization'
       responses:
         204:
-          description: No Content (success)
+          description: 'No Content (success)'
         404:
-          description: Organization not found
+          description: 'Organization not found'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Deactivate platform organization
+      summary: 'Deactivate platform organization'
       tags:
         - Platforms
       parameters:
@@ -546,20 +545,20 @@ paths:
         - $ref: '#/parameters/organizationID'
       responses:
         204:
-          description: No Content (success)
+          description: 'No Content (success)'
         404:
-          description: Organization not found
+          description: 'Organization not found'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /platforms/{platformID}/organizations/{organizationID}/members/:
     x-resource: Platforms
     get:
-      summary: Fetch organization member list
+      summary: 'Fetch organization member list'
       tags:
         - Platforms
       parameters:
@@ -570,40 +569,40 @@ paths:
         - $ref: '#/parameters/search'
       responses:
         200:
-          description: Organization members
+          description: 'Paginated Organization members'
           schema:
             $ref: '#/definitions/UserWithRolePaginated'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Move a user to the organization
+      summary: 'Move a user to the organization'
       tags:
         - Platforms
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
         - name: userOrganizationRole
-          description: Role that the user will have in the organization
+          description: 'Role that the user will have in the organization'
           in: body
           schema:
             $ref: '#/definitions/UserRole'
       responses:
         200:
-          description: Modified roles
+          description: 'Modified roles'
           schema:
             type: array
             items:
               $ref: '#/definitions/UserGroupRole'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/teams/:
     x-resource: Platforms
     get:
-      summary: Fetch organization teams
+      summary: 'Fetch organization teams'
       tags:
         - Platforms
       parameters:
@@ -613,15 +612,15 @@ paths:
         - $ref: '#/parameters/page'
       responses:
         200:
-          description: Organization teams
+          description: 'Organization teams'
           schema:
             $ref: '#/definitions/TeamsPaginated'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Create organization team
+      summary: 'Create organization team'
       tags:
         - Platforms
       parameters:
@@ -634,17 +633,17 @@ paths:
             $ref: '#/definitions/TeamCreate'
       responses:
         201:
-          description: Team Created
+          description: 'Team Created'
           schema:
             $ref: '#/definitions/Team'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/teams/{teamID}/:
     x-resource: Platforms
     get:
-      summary: Fetch team
+      summary: 'Fetch team'
       tags:
         - Platforms
       parameters:
@@ -653,15 +652,19 @@ paths:
         - $ref: '#/parameters/teamID'
       responses:
         200:
-          description: Team
+          description: 'Team found'
           schema:
             $ref: '#/definitions/Team'
+        404:
+          description: 'Team not found'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update team
+      summary: 'Update team'
       tags:
         - Platforms
       parameters:
@@ -675,13 +678,13 @@ paths:
             $ref: '#/definitions/Team'
       responses:
         204:
-          description: No Content (success)
+          description: 'No Content (success)'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete team
+      summary: 'Delete team'
       tags:
         - Platforms
       parameters:
@@ -690,15 +693,15 @@ paths:
         - $ref: '#/parameters/teamID'
       responses:
         204:
-          description: No Content (success)
+          description: 'No Content (success)'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/teams/{teamID}/members/:
     x-resource: Platforms
     get:
-      summary: Fetch team members
+      summary: 'Fetch team members'
       tags:
         - Platforms
       parameters:
@@ -710,15 +713,15 @@ paths:
         - $ref: '#/parameters/search'
       responses:
         200:
-          description: Organization teams
+          description: 'Organization teams'
           schema:
             $ref: '#/definitions/TeamsPaginated'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Add team member
+      summary: 'Add team member'
       tags:
         - Platforms
       parameters:
@@ -732,19 +735,19 @@ paths:
             $ref: '#/definitions/UserRole'
       responses:
         200:
-          description: List of modified user roles
+          description: 'List of modified user roles'
           schema:
             type: array
             items:
               $ref: '#/definitions/UserGroupRole'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/teams/{teamID}/members/{userID}:
     x-resource: Platforms
     delete:
-      summary: Remove team member
+      summary: 'Remove team member'
       tags:
         - Platforms
       parameters:
@@ -754,20 +757,20 @@ paths:
         - $ref: '#/parameters/userID'
       responses:
         200:
-          description: List of modified user roles
+          description: 'List of modified user roles'
           schema:
             type: array
             items:
               $ref: '#/definitions/UserGroupRole'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /datasources/:
     x-resource: Datasources
     get:
-      summary: Get a list of datasources
+      summary: 'Get a list of datasources'
       description: |
         Datasources are sensors that share common metadata, like default color corrections. Scenes from
         a given datasource can be mosaiced and color corrected together.
@@ -776,12 +779,15 @@ paths:
       parameters:
         - $ref: '#/parameters/owner'
         - $ref: '#/parameters/name'
-      # TODO: fill in all possible responses
       responses:
         200:
           description: SUCCESS
           schema:
             $ref: '#/definitions/DatasourcePaginated'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
       summary: Create a datasource
       description: |
@@ -792,31 +798,40 @@ paths:
       parameters:
         - $ref: '#/parameters/owner'
         - $ref: '#/parameters/name'
-      # TODO: fill in all possible responses
       responses:
         201:
           description: SUCCESS
           schema:
             $ref: '#/definitions/Datasource'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /datasources/{uuid}/permissions/:
     x-resource: Datasources
     get:
-      summary: List access control rules for this datasource
+      summary: 'List access control rules for this datasource'
       parameters:
         - $ref: '#/parameters/uuid'
       tags:
         - Permissions
       responses:
         200:
-          description: All access control rules for this datasource
+          description: 'All access control rules for this datasource'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
         403:
-          description: Insufficient permissions to list permissions on this datasource
+          description: 'Insufficient permissions to list permissions on this datasource'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Replace permissions defined on this datasource
+      summary: 'Replace permissions defined on this datasource'
       tags:
         - Permissions
       parameters:
@@ -830,13 +845,21 @@ paths:
               $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rules replaced with response successfully
+          description: 'Access control rules replaced with response successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Add a new access control rule to this datasource
+      summary: 'Add a new access control rule to this datasource'
       tags:
         - Permissions
       parameters:
@@ -848,15 +871,23 @@ paths:
             $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rule appended successfully
+          description: 'Access control rule appended successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /uploads/:
     x-resource: Uploads
     get:
-      summary: Get a list of uploads
+      summary: 'Get a list of uploads'
       description: |
         The uploads API endpoint enables searching, listing, and creating new uploads.
       tags:
@@ -871,15 +902,15 @@ paths:
         - $ref: '#/parameters/owner'
       responses:
         200:
-          description: Paginated list of uploads
+          description: 'Paginated list of uploads'
           schema:
             $ref: '#/definitions/UploadPaginated'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Create an upload
+      summary: 'Create an upload'
       description: |
         Create a new upload.
       tags:
@@ -891,34 +922,37 @@ paths:
             $ref: '#/definitions/UploadCreate'
       responses:
         201:
-          description: Upload created
+          description: 'Upload created'
           schema:
             $ref: '#/definitions/Upload'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /uploads/{uuid}/:
     x-resource: Uploads
     get:
-      summary: Get upload details
+      summary: 'Get upload details'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Info about upload
+          description: 'Info about upload'
           schema:
             $ref: '#/definitions/Upload'
-        404:
-          description: |
-            UUID parameter does not refer to an upload or the user is not able to view the upload it refers to
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update an upload
-      description: Update an existing upload
+      summary: 'Update an upload'
+      description: 'Update an existing upload'
       tags:
         - Imagery
       parameters:
@@ -930,34 +964,36 @@ paths:
             $ref: '#/definitions/UploadCreate'
       responses:
         204:
-          description: Update successful (no further processing needed)
-        404:
-          description: |
-            The UUID parameter does not refer to a upload or the user does not have access to the upload it refers to
+          description: 'Update successful (no further processing needed)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete an upload
+      summary: 'Delete an upload'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Deletion successful (no content)
-        404:
-          description: |
-            The UUID parameter does not refer to an upload or the user does not have access to the upload it refers to
+          description: 'Deletion successful (no content)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /uploads/{uuid}/credentials/:
     x-resource: Uploads
     get:
-      summary: Get credentials for an AWS S3 bucket
+      summary: 'Get credentials for an AWS S3 bucket'
       tags:
         - Authentication
         - Imagery
@@ -965,17 +1001,21 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: AWS credentials scoped to the upload bucket with prefix
+          description: 'AWS credentials scoped to the upload bucket with prefix'
           schema:
             $ref: '#/definitions/UploadCredentialsResponse'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /scenes/:
     x-resource: Scenes
     get:
-      summary: Get a list of scenes
+      summary: 'Get a list of scenes'
       tags:
         - Imagery
       parameters:
@@ -1010,10 +1050,10 @@ paths:
           in: query
           type: string
           format: uuid
-          description: UUID of a shape in shapes table
+          description: 'UUID of a shape in shapes table'
       responses:
         200:
-          description: Paginated list of scenes
+          description: 'Paginated list of scenes'
           schema:
             $ref: '#/definitions/ScenePaginated'
     post:
@@ -1028,33 +1068,40 @@ paths:
             $ref: '#/definitions/Scene'
       responses:
         201:
-          description: Successfully created a new scene
+          description: 'Successfully created a new scene'
           schema:
             $ref: '#/definitions/Scene'
         400:
-          description: Client error creating a scene
+          description: 'Client error creating a scene'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /scenes/{uuid}/:
     x-resource: Scenes
     get:
-      summary: Get scene details
+      summary: 'Get scene details'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Info about Scene
+          description: 'Info about Scene'
           schema:
             $ref: '#/definitions/Scene'
-        404:
-          description: |
-            UUID parameter does not refer to an scene or the user is not able to view the scene it refers to
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update a scene
+      summary: 'Update a scene'
       tags:
         - Imagery
       parameters:
@@ -1066,18 +1113,17 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Update successful (no further processing needed)
-        404:
-          description: |
-            The UUID parameter does not refer to a scene or the user does not have access to the scene it refers to
+          description: 'Update successful (no further processing needed)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete a scene
+      summary: 'Delete a scene'
       description: |
         Warning: this will delete any associated imagery as well.
 
@@ -1087,51 +1133,63 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Deletion successful (no content)
-        404:
-          description: |
-            The UUID parameter does not refer to a scene or the user does not have access to the scene it refers to
+          description: 'Deletion successful (no content)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /scenes/{uuid}/download:
     x-resource: Scenes
     get:
-      summary: Get list of downloadable Images
+      summary: 'Get list of downloadable Images'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: An array of downloadable images. Each image has a `downloadUri` property.
+          description: 'An array of downloadable images. Each image has a `downloadUri` property.'
           schema:
             type: array
             items:
               $ref: '#/definitions/ImageWithDownloadUri'
-        404:
-          description: |
-            UUID parameter does not refer to an scene or the user is not able to view the scene it refers to
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /scenes/{uuid}/permissions/:
     x-resource: Scenes
     get:
-      summary: List access control rules for this scene
+      summary: 'List access control rules for this scene'
       parameters:
         - $ref: '#/parameters/uuid'
       tags:
         - Permissions
       responses:
         200:
-          description: All access control rules for this scene
+          description: 'All access control rules for this scene'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
         403:
-          description: Insufficient permissions to list permissions on this scene
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Replace permissions defined on this scene
+      summary: 'Replace permissions defined on this scene'
       tags:
         - Permissions
       parameters:
@@ -1145,13 +1203,21 @@ paths:
               $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rules replaced with response successfully
+          description: 'Access control rules replaced with response successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Add a new access control rule to this scene
+      summary: 'Add a new access control rule to this scene'
       tags:
         - Permissions
       parameters:
@@ -1163,71 +1229,44 @@ paths:
             $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rule appended successfully
+          description: 'Access control rule appended successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /scenes/{uuid}/datasource:
     x-resource: Scenes
     get:
-      summary: Get the datasource for a scene you can view
-    tags:
-      - Imagery
-    parameters:
-      - $ref: '#/parameters/uuid'
-    responses:
-      200:
-        description: A datasource
-        schema:
-          $ref: '#/definitions/Datasource'
-      403:
-        description: The scene does not exist or the requesting user cannot view it
-        schema:
-          $ref: '#/definitions/Error'
-  /scene-grid/{zoom}/{column}/{row}/:
-    x-resource: Scenes
-    get:
-      summary: Get scene statistics for a tile
+      summary: 'Get the datasource for a scene you can view'
       tags:
-        - Statistics
+        - Imagery
       parameters:
-        - $ref: '#/parameters/column'
-        - $ref: '#/parameters/row'
-        - $ref: '#/parameters/zoom'
-        - $ref: '#/parameters/organization'
-        - $ref: '#/parameters/maxCloudCover'
-        - $ref: '#/parameters/minCloudCover'
-        - $ref: '#/parameters/minAcquisitionDatetime'
-        - $ref: '#/parameters/maxAcquisitionDatetime'
-        - $ref: '#/parameters/minCreateDatetime'
-        - $ref: '#/parameters/maxCreateDatetime'
-        - $ref: '#/parameters/datasource'
-        - $ref: '#/parameters/month'
-        - $ref: '#/parameters/minDayOfMonth'
-        - $ref: '#/parameters/maxDayOfMonth'
-        - $ref: '#/parameters/maxSunAzimuth'
-        - $ref: '#/parameters/minSunAzimuth'
-        - $ref: '#/parameters/maxSunElevation'
-        - $ref: '#/parameters/minSunElevation'
-        - $ref: '#/parameters/minResolution'
-        - $ref: '#/parameters/maxResolution'
-        - $ref: '#/parameters/tags'
-        - $ref: '#/parameters/ingested'
-        - $ref: '#/parameters/ingestStatus'
+        - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Statistics for the given bounding box
+          description: 'A datasource'
           schema:
-            $ref: '#/definitions/SceneGrid'
-        400:
-          description: Invalid Parameters
+            $ref: '#/definitions/Datasource'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /projects/:
     x-resource: Projects
     get:
-      summary: Get a list of projects
+      summary: 'Get a list of projects'
       description:  |
         Only projects that the user has permission to view will be returned.
       tags:
@@ -1241,11 +1280,15 @@ paths:
         - $ref: '#/parameters/tags'
       responses:
         200:
-          description: Paginated list of projects the user is authorized to view
+          description: 'Paginated list of projects the user is authorized to view'
           schema:
             $ref: '#/definitions/ProjectPaginated'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Create a project
+      summary: 'Create a project'
       tags:
         - Imagery
       parameters:
@@ -1256,29 +1299,36 @@ paths:
             $ref: '#/definitions/Project'
       responses:
         201:
-          description: Project details; at this point scene processes may be in-progress
+          description: 'Project details; at this point scene processes may be in-progress'
           schema:
             $ref: '#/definitions/Project'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /projects/{uuid}/:
     x-resource: Projects
     get:
-      summary: Get project details
+      summary: 'Get project details'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Info about Project
+          description: 'Project details found'
           schema:
             $ref: '#/definitions/Project'
-        404:
-          description: |
-            UUID parameter does not refer to a project or the user is not able to view the project it refers to
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update a project
+      summary: 'Update a project'
       tags:
         - Imagery
       parameters:
@@ -1290,48 +1340,59 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Update successful (no further processing needed)
-        404:
-          description: |
-            The UUID parameter does not refer to a project or the user does not have access to the project it refers to
+          description: 'Update successful (no further processing needed)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete a project
+      summary: 'Delete a project'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Deletion successful (no content)
-        404:
-          description: The UUID parameter does not refer to a project or the user does not have access to the project it refers to
+          description: 'Deletion successful (no content)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /projects/{uuid}/labels/:
     x-resource: Projects
     get:
-      summary: Get a list of the labels used on a project
+      summary: 'Get a list of the labels used on a project'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: A list of labels
+          description: 'A list of labels'
           schema:
             type: array
             items:
               type: string
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /projects/{uuid}/annotations/:
     x-resource: Projects
     get:
-      summary: Get annotations belonging to a project
+      summary: 'Get annotations belonging to a project'
       tags:
         - Imagery
       parameters:
@@ -1342,12 +1403,20 @@ paths:
         - $ref: '#/parameters/pageSize'
       responses:
         200:
-          description: GeoJSON feature collection containing paginated annotations of this project
+          description: 'GeoJSON feature collection containing paginated annotations of this project'
           schema:
             $ref: '#/definitions/AnnotationFeatureCollectionPaginated'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
     post:
-      summary: Create annotations for a project
+      summary: 'Create annotations for a project'
       tags:
         - Imagery
       parameters:
@@ -1359,31 +1428,39 @@ paths:
             $ref: '#/definitions/AnnotationFeatureCollectionCreate'
       responses:
         201:
-          description: GeoJSON annotations successfully created
+          description: 'GeoJSON annotations successfully created'
           schema:
             $ref: '#/definitions/AnnotationFeatureCollection'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error.
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete all annotations from a project
+      summary: 'Delete all annotations from a project'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         201:
-          description: Annotations Deleted
+          description: 'Annotations Deleted'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error.
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /projects/{uuid}/annotations/{uuid2}:
     x-resouce: Projects
     get:
-      summary: Get an annotation belonging to a project
+      summary: 'Get an annotation belonging to a project'
       tags:
         - Imagery
       parameters:
@@ -1391,12 +1468,20 @@ paths:
         - $ref: '#/parameters/uuid2'
       responses:
         200:
-          description: GeoJSON feature containing one annotation from this project
+          description: 'GeoJSON feature containing one annotation from this project'
           schema:
             $ref: '#/definitions/AnnotationFeature'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
     put:
-      summary: Update an annotation of this project
+      summary: 'Update an annotation of this project'
       tags:
         - Imagery
       parameters:
@@ -1409,10 +1494,18 @@ paths:
             $ref: '#/definitions/AnnotationFeatureUpdate'
       responses:
         204:
-          description: No content, update successful
+          description: 'No content, update successful'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
     delete:
-      summary: Delete an annotation
+      summary: 'Delete an annotation'
       tags:
         - Imagery
       parameters:
@@ -1420,9 +1513,13 @@ paths:
         - $ref: '#/parameters/uuid2'
       responses:
         204:
-          description: Deletion successful.
-        404:
-          description: The UUID parameter does not refer to an annotation or the user does not have access to the project it refers to.
+          description: 'Deletion successful.'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
@@ -1430,7 +1527,7 @@ paths:
   /projects/{uuid}/areas-of-interest/:
     x-resource: Projects
     get:
-      summary: Get all areas of interest for a project
+      summary: 'Get all areas of interest for a project'
       tags:
         - Imagery
       parameters:
@@ -1439,12 +1536,20 @@ paths:
         - $ref: '#/parameters/page'
       responses:
         200:
-          description: Json summary of the filters and Polygons that make up AOIs for the given project.
+          description: 'JSON summary of the filters and Polygons that make up AOIs for the given project.'
           schema:
             $ref: '#/definitions/AoiPaginated'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
     post:
-      summary: Create an area of interest for a project
+      summary: 'Create an area of interest for a project'
       tags:
         - Imagery
       parameters:
@@ -1456,18 +1561,22 @@ paths:
             $ref: '#/definitions/AOI'
       responses:
         201:
-          description: Area of Interest created.
+          description: 'Area of Interest created.'
           schema:
             $ref: '#/definitions/AOI'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error.
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /projects/{uuid}/scenes/:
     x-resource: Projects
     get:
-      summary: Get a list of scenes associated with a project
+      summary: 'Get a list of scenes associated with a project'
       tags:
         - Imagery
       parameters:
@@ -1498,11 +1607,19 @@ paths:
         - $ref: '#/parameters/pending'
       responses:
         200:
-          description: Paginated list of scenes associated with this project
+          description: 'Paginated list of scenes associated with this project'
           schema:
             $ref: '#/definitions/ScenePaginated'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Add scenes to a project by their ID
+      summary: 'Add scenes to a project by their ID'
       tags:
         - Imagery
       parameters:
@@ -1510,7 +1627,7 @@ paths:
         - name: scenes
           in: body
           required: true
-          description: UUIDs of scenes to place in project
+          description: 'UUIDs of scenes to place in project'
           schema:
             type: array
             items:
@@ -1518,13 +1635,21 @@ paths:
               format: uuid
       responses:
         201:
-          description: List of scenes added to project
+          description: 'List of scenes added to project'
           schema:
             type: array
             items:
               $ref: '#/definitions/Scene'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Replace scenes in a project
+      summary: 'Replace scenes in a project'
       tags:
         - Imagery
       parameters:
@@ -1532,7 +1657,7 @@ paths:
         - name: scenes
           in: body
           required: true
-          description: UUIDs of scenes to replace in project
+          description: 'UUIDs of scenes to replace in project'
           schema:
             type: array
             items:
@@ -1540,16 +1665,24 @@ paths:
               format: uuid
       responses:
         204:
-          description: No content, update successful
+          description: 'No content, update successful'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     delete:
-      summary: Delete scenes from a project
+      summary: 'Delete scenes from a project'
       tags:
         - Imagery
       parameters:
         - name: scenes
           in: body
           required: true
-          description: UUIDs of scenes to delete in project
+          description: 'UUIDs of scenes to delete in project'
           schema:
             type: array
             items:
@@ -1558,11 +1691,19 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: No content, delete successful
+          description: 'No content, delete successful'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
   /projects/{uuid}/scenes/{uuid2}/accept:
     post:
-      summary: Approve a pending scene which has passed an area of interest check.
+      summary: 'Approve a pending scene which has passed an area of interest check.'
       tags:
         - Imagery
       parameters:
@@ -1570,11 +1711,19 @@ paths:
         - $ref: '#/parameters/uuid2'
       responses:
         204:
-          description: Successfully accepted the Scene.
+          description: 'Successfully accepted the Scene.'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
   /projects/{uuid}/scenes/accept:
     post:
-      summary: Approve a list of pending scenes which have passed an area of interest check.
+      summary: 'Approve a list of pending scenes which have passed an area of interest check.'
       tags:
         - Imagery
       parameters:
@@ -1582,34 +1731,50 @@ paths:
         - name: scenes
           in: body
           required: true
-          description: UUIDs of scenes to approve
+          description: 'UUIDs of scenes to approve'
           schema:
             $ref: '#/definitions/BulkAcceptParams'
       responses:
         204:
-          description: Successfully accepted scenes
+          description: 'Successfully accepted scenes'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
 
   /projects/{uuid}/scenes/bulk-add-from-query/:
     x-resource: Projects
     post:
-      summary: Add scenes to a project based on search parameters
+      summary: 'Add scenes to a project based on search parameters'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
         - name: combinedSceneQueryParameters
-          description: combined query parameters for finding scenes to add to this project
+          description: 'combined query parameters for finding scenes to add to this project'
           in: body
           schema:
             $ref: '#/definitions/CombinedSceneQueryParams'
       responses:
         201:
-          description: List of scenes added to project
+          description: 'List of scenes added to project'
           schema:
             type: array
             items:
               $ref: '#/definitions/Scene'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
   /projects/{uuid}/mosaic/:
     x-resource: Projects
@@ -1621,26 +1786,42 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: An ordered list of scene IDs and corresponding color correction parameters
+          description: 'An ordered list of scene IDs and corresponding color correction parameters'
           schema:
             $ref: '#/definitions/MosaicDefinition'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
   /projects/{uuid}/mosaic/bulk-update-color-corrections/:
     x-resource: Projects
     post:
-      summary: Save color-correction parameters for all scenes in a project
+      summary: 'Save color-correction parameters for all scenes in a project'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
         - name: combinedSceneCorrectionParameters
-          description: Combined color correction parameters
+          description: 'Combined color correction parameters'
           in: body
           schema:
             $ref: '#/definitions/CombinedSceneCorrectionParams'
       responses:
         200:
           description: "Successfully updated all scenes' color correction parameters"
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
   /projects/{uuid}/mosaic/{uuid2}:
     x-resource: Projects
@@ -1653,66 +1834,102 @@ paths:
         - $ref: '#/parameters/uuid2'
       responses:
         200:
-          description: Color correction parameters
+          description: 'Color correction parameters'
           schema:
             $ref: '#/definitions/ColorCorrection'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Save color-correction parameters for a particular scene
+      summary: 'Save color-correction parameters for a particular scene'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
         - $ref: '#/parameters/uuid2'
         - name: updatedColorCorrection
-          description: Updated color corrections
+          description: 'Updated color corrections'
           in: body
           schema:
             $ref: '#/definitions/ColorCorrection'
       responses:
         204:
-          description: Successfully updated color correction parameters
+          description: 'Successfully updated color correction parameters'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /projects/{uuid}/order:
     x-resource: Projects
     get:
-      summary: Get a list of scene IDs belonging to a project
+      summary: 'Get a list of scene IDs belonging to a project'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
-      # TODO: fill in all possible responses
       responses:
         200:
-          description: Order of scenes in project for mosaic purposes
+          description: 'Order of scenes in project for mosaic purposes'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Set a z-index order for scenes within the specified project
+      summary: 'Set a z-index order for scenes within the specified project'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
-      # TODO: fill in all possible responses
       responses:
         204:
-          description: Successfully updated order of scenes in project
+          description: 'Successfully updated order of scenes in project'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
   /projects/{uuid}/permissions/:
     x-resource: Projects
     get:
-      summary: List access control rules for this project
+      summary: 'List access control rules for this project'
       parameters:
         - $ref: '#/parameters/uuid'
       tags:
         - Permissions
       responses:
         200:
-          description: All access control rules for this project
+          description: 'All access control rules for this project'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
         403:
-          description: Insufficient permissions to list permissions on this project
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Replace permissions defined on this project
+      summary: 'Replace permissions defined on this project'
       tags:
         - Permissions
       parameters:
@@ -1726,13 +1943,21 @@ paths:
               $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rules replaced with response successfully
+          description: 'Access control rules replaced with response successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Add a new access control rule to this project
+      summary: 'Add a new access control rule to this project'
       tags:
         - Permissions
       parameters:
@@ -1744,15 +1969,23 @@ paths:
             $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rule appended successfully
+          description: 'Access control rule appended successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
   /areas-of-interest/:
     get:
-      summary: Get a list of areas of interest
+      summary: 'Get a list of areas of interest'
       tags:
         - Imagery
       parameters:
@@ -1762,22 +1995,30 @@ paths:
         - $ref: '#/parameters/owner'
       responses:
         200:
-          description: A paginated list of all AOIs the user is authorized to view.
+          description: 'A paginated list of all AOIs the user is authorized to view.'
           schema:
             $ref: '#/definitions/AoiPaginated'
 
   /areas-of-interest/{uuid}/:
     get:
-      summary: Get a specific area of interest
+      summary: 'Get a specific area of interest'
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: "Json summary of the given AOI's filters and Polygons."
+          description: "JSON summary of the given AOI's filters and Polygons."
           schema:
             $ref: '#/definitions/AOI'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Update an area of interest
+      summary: 'Update an area of interest'
       tags:
         - Imagery
       parameters:
@@ -1789,33 +2030,37 @@ paths:
             $ref: '#/definitions/AOI'
       responses:
         204:
-          description: Update successful.
-        404:
-          description: The UUID parameter does not refer to a project or the user does not have access to the project it refers to.
+          description: 'Update successful.'
+        403:
+          description: 'Insufficient permissions or object does not exist'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error.
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete a project
+      summary: 'Delete a project'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Deletion successful.
-        404:
-          description: The UUID parameter does not refer to a project or the user does not have access to the project it refers to.
+          description: 'Deletion successful.'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /map-tokens/:
     x-resource: Tokens
     get:
-      summary: Get a list of map tokens
+      summary: 'Get a list of map tokens'
       description: |
         Map tokens are filtered by user
       tags:
@@ -1828,15 +2073,15 @@ paths:
         - $ref: '#/parameters/project'
       responses:
         200:
-          description: Paginated list of map tokens
+          description: 'Paginated list of map tokens'
           schema:
             $ref: '#/definitions/MapTokenPaginated'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Create a map token
+      summary: 'Create a map token'
       tags:
         - Imagery
       parameters:
@@ -1846,33 +2091,36 @@ paths:
             $ref: '#/definitions/MapToken'
       responses:
         201:
-          description: Map token created
+          description: 'Map token created'
           schema:
             $ref: '#/definitions/MapToken'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /map-tokens/{uuid}/:
     x-resource: Tokens
     get:
-      summary: Get map token details
+      summary: 'Get map token details'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Info about map token
+          description: 'Info about map token'
           schema:
             $ref: '#/definitions/MapToken'
-        404:
-          description: |
-            UUID parameter does not refer to a map token or the user is not able to view the token it refers to
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update a map token
+      summary: 'Update a map token'
       tags:
         - Imagery
       parameters:
@@ -1884,28 +2132,30 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Update successful (no further processing needed)
-        404:
-          description: |
-            The UUID parameter does not refer to a map token or the user does not have access to the token it refers to
+          description: 'Update successful (no further processing needed)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete a map token
+      summary: 'Delete a map token'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Deletion successful (no content)
-        404:
-          description: |
-            The UUID parameter does not refer to a map token or the user does not have access to the token it refers to
+          description: 'Deletion successful (no content)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /tokens/:
@@ -1919,13 +2169,13 @@ paths:
         - Authentication
       responses:
         200:
-          description: List of refresh token identifiers
+          description: 'List of refresh token identifiers'
           schema:
             type: array
             items:
               $ref: '#/definitions/RefreshToken'
         404:
-          description: No refresh tokens found for user
+          description: 'No refresh tokens found for user'
           schema:
             $ref: '#/definitions/Error'
     post:
@@ -1935,22 +2185,28 @@ paths:
         - name: refreshToken
           in: body
           required: true
-          description: Refresh token object to use when requesting a new JWT
+          description: 'Refresh token object to use when requesting a new JWT'
           schema:
             type: object
             properties:
               refresh_token:
                 type: string
-                description: Refresh token used to generate new JWT
+                description: 'Refresh token used to generate new JWT'
       tags:
         - Authentication
       responses:
         201:
-          description: Retrieved a new auth token
+          description: 'Retrieved a new auth token'
           schema:
             $ref: '#/definitions/AuthToken'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Error message if insufficient permissions are present
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /tokens/{refreshTokenId}/:
     x-resource: Tokens
     delete:
@@ -1959,16 +2215,24 @@ paths:
           in: path
           required: true
           type: string
-      summary: Delete a refresh token and revoke its access
+      summary: 'Delete a refresh token and revoke its access'
       tags:
         - Authentication
       responses:
         204:
-          description: Revocation successful, No Content
+          description: 'Revocation successful, No Content'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /tools/:
     x-resource: Tools
     get:
-      summary: Get a list of tools
+      summary: 'Get a list of tools'
       tags:
         - Lab
       parameters:
@@ -1983,65 +2247,85 @@ paths:
         - $ref: '#/parameters/search'
       responses:
         200:
-          description: Returns a paginated list of tools
+          description: 'Returns a paginated list of tools'
           schema:
             $ref: '#/definitions/ToolPaginated'
-        404:
-          description: Error message if insufficient permissions or objects not present
         default:
-          description: Error message if insufficient permissions
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Create a tool
+      summary: 'Create a tool'
       tags:
         - Lab
       responses:
         201:
-          description: Create a new geoprocessing tool
+          description: 'Create a new geoprocessing tool'
           schema:
             $ref: '#/definitions/Tool'
         default:
-          description: Error message if insufficient permissions to create a new tool
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /tools/{uuid}/:
     x-resource: Tools
     get:
-      summary: Get details for a particular tool
+      summary: 'Get details for a particular tool'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Geoprocessing tool record
+          description: 'Geoprocessing tool record'
           schema:
             $ref: '#/definitions/Tool'
-        404:
-          description: Error message returned if insufficent permissions or tool does not exist
-    delete:
-      summary: Delete a tool
-      tags:
-        - Lab
-      parameters:
-        - $ref: '#/parameters/uuid'
-      responses:
-        204:
-          description: Delete successful
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Delete unsuccessful, either object did not exist or insufficient permissions
-    put:
-      summary: Update a tool
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: 'Delete a tool'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Update an existing geoprocessing tool
-        404:
-          description: Error message if insufficient permissions to update a tool
+          description: 'Delete successful'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: 'Update a tool'
+      tags:
+        - Lab
+      parameters:
+        - $ref: '#/parameters/uuid'
+      responses:
+        204:
+          description: 'Update an existing geoprocessing tool'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /tool-tags/:
     x-resource: Tools
     get:
-      summary: Get a list of tool tags
+      summary: 'Get a list of tool tags'
       tags:
         - Lab
       parameters:
@@ -2049,41 +2333,51 @@ paths:
         - $ref: '#/parameters/owner'
       responses:
         200:
-          description: Retrieve a paginated list of tool tags
+          description: 'Retrieve a paginated list of tool tags'
           schema:
             $ref: '#/definitions/ToolTagPaginated'
-        404:
-          description: Error message if insufficent permissions or no tools exist
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Create a tool tag
+      summary: 'Create a tool tag'
       tags:
         - Lab
       responses:
         201:
-          description: Successfully created a new tag for tools
+          description: 'Successfully created a new tag for tools'
           schema:
             $ref: '#/definitions/ToolTag'
         default:
-          description: Error message if insufficient permissions to create a tool
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /tools/{uuid}/permissions/:
     x-resource: Tools
     get:
-      summary: List access control rules for this tool
+      summary: 'List access control rules for this tool'
       parameters:
         - $ref: '#/parameters/uuid'
       tags:
         - Permissions
       responses:
         200:
-          description: All access control rules for this tool
+          description: 'All access control rules for this tool'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
         403:
-          description: Insufficient permissions to list permissions on this tool
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Replace permissions defined on this tool
+      summary: 'Replace permissions defined on this tool'
       tags:
         - Permissions
       parameters:
@@ -2097,13 +2391,21 @@ paths:
               $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rules replaced with response successfully
+          description: 'Access control rules replaced with response successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Add a new access control rule to this tool
+      summary: 'Add a new access control rule to this tool'
       tags:
         - Permissions
       parameters:
@@ -2115,107 +2417,175 @@ paths:
             $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rule appended successfully
+          description: 'Access control rule appended successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /tool-tags/{uuid}/:
     x-resource: Tools
     get:
-      summary: Get the details of a tool tag
+      summary: 'Get the details of a tool tag'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Successfully retrieved a tool
+          description: 'Successfully retrieved a tool tag'
           schema:
             $ref: '#/definitions/ToolTag'
-        404:
-          description: Error message if insufficient permissions or tag does not exist
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     delete:
-      summary: Delete a tool tag
+      summary: 'Delete a tool tag'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Successfully deleted a tag
+          description: 'Successfully deleted a tag'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Error message if insufficient permissions to delete a tag
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Update a tool tag
+      summary: 'Update a tool tag'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Successfully updated tag
+          description: 'Successfully updated tag'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unable to delete tag due to insufficient permissions or tag does not exist
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /tool-categories/:
     x-resource: Tools
     get:
-      summary: Get a list of tool categories
+      summary: 'Get a list of tool categories'
       parameters:
         - $ref: '#/parameters/search'
       tags:
         - Lab
       responses:
         200:
-          description: Paginated list of tool categories
+          description: 'Paginated list of tool categories'
           schema:
             $ref: '#/definitions/ToolCategoryPaginated'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Create a tool category
+      summary: 'Create a tool category'
       tags:
         - Lab
       responses:
         201:
-          description: Successfully created a new tool category
+          description: 'Successfully created a new tool category'
           schema:
             $ref: '#/definitions/ToolCategory'
+        403:
+          description: 'Insufficient permissions'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
   /tool-categories/{slugLabel}/:
     x-resource: Tools
     get:
-      summary: Get the details of a tool category
+      summary: 'Get the details of a tool category'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/slugLabel'
       responses:
         200:
-          description: Retrieved a single tool category
+          description: 'Retrieved a single tool category'
           schema:
             $ref: '#/definitions/ToolCategory'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Update a tool category
+      summary: 'Update a tool category'
       tags:
         - Lab
       responses:
         204:
-          description: Successfully updated a tool category
+          description: 'Successfully updated a tool category'
+        400:
+          description: 'Invalid object structure'
+          schema:
+            $ref: '#/definitions/Error'
+        403:
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
       parameters:
         - $ref: '#/parameters/slugLabel'
     delete:
-      summary: Delete a tool category
+      summary: 'Delete a tool category'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/slugLabel'
       responses:
         204:
-          description: Successfully deleted a tool category
+          description: 'Successfully deleted a tool category'
+        403:
+          description: 'Insufficient permissions or tool not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
+          
   /tool-runs/:
     x-resource: Tools
     get:
-      summary: Get a list of tool runs
+      summary: 'Get a list of tool runs'
       description: |
-        A tool run is a specific implementation of a tool. Tool runs can specify inputs and parameters neccessary to execute a tool.
+        A tool run is a specific implementation of a tool.
+        Tool runs can specify inputs and parameters neccessary to execute a tool.
       tags:
         - Lab
       parameters:
@@ -2227,74 +2597,114 @@ paths:
         - $ref: '#/parameters/createdBy'
       responses:
         200:
-          description: Paginated list of tool runs
+          description: 'Paginated list of tool runs'
           schema:
             $ref: '#/definitions/ToolRunPaginated'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Create a tool run
+      summary: 'Create a tool run'
       tags:
         - Lab
       responses:
         201:
-          description: Successfully created tool run
+          description: 'Successfully created tool run'
           schema:
             $ref: '#/definitions/ToolRun'
         400:
-          description: Incorrect values for creating tool run
+          description: 'Invalid object structure for tool run'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
   /tool-runs/{uuid}/:
     x-resource: Tools
     get:
-      summary: Get details about a tool run
+      summary: 'Get details about a tool run'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Details about object
+          description: 'Details about object'
           schema:
             $ref: '#/definitions/ToolRun'
-        404:
-          description: Error if insufficient permissions or run not found
+        403:
+          description: 'Insufficient permissions or tool run not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Update a tool run
+      summary: 'Update a tool run'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Successfully updated tool run
+          description: 'Successfully updated tool run'
         400:
-          description: Bad parameters for updating tool run
+          description: 'Invalid object structure for tool run'
+          schema:
+            $ref: '#/definitions/Error'
+        403:
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
     delete:
-      summary: Delete a tool run
+      summary: 'Delete a tool run'
       tags:
         - Lab
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Successfully deleted a tool run
+          description: 'Successfully deleted a tool run'
+        403:
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
   /tool-runs/{uuid}/permissions/:
     x-resource: Tools
     get:
-      summary: List access control rules for this tool run
+      summary: 'List access control rules for this tool run'
       parameters:
         - $ref: '#/parameters/uuid'
       tags:
         - Permissions
       responses:
         200:
-          description: All access control rules for this tool run
+          description: 'All access control rules for this tool run'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
         403:
-          description: Insufficient permissions to list permissions on this tool run
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Replace permissions defined on this tool run
+      summary: 'Replace permissions defined on this tool run'
       tags:
         - Permissions
       parameters:
@@ -2308,13 +2718,21 @@ paths:
               $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rules replaced with response successfully
+          description: 'Access control rules replaced with response successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Add a new access control rule to this tool run
+      summary: 'Add a new access control rule to this tool run'
       tags:
         - Permissions
       parameters:
@@ -2326,25 +2744,37 @@ paths:
             $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rule appended successfully
+          description: 'Access control rule appended successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
   /feed/:
     get:
-      summary: Get the cached RSS feed
+      summary: 'Get the cached RSS feed'
       parameters:
         - $ref: '#/parameters/source'
       tags:
         - Users
       responses:
         200:
-          description: RSS feed json as a string
+          description: 'RSS feed json as a string'
+        default:
+          description: 'Unexpected Error'
+          schema:
+            $ref: '#/definitions/Error'
   /exports/:
     x-resource: Exports
     get:
-      summary: Get a list of exports
+      summary: 'Get a list of exports'
       tags:
         - Imagery
       parameters:
@@ -2357,15 +2787,19 @@ paths:
         - $ref: '#/parameters/exportStatus'
       responses:
         200:
-          description: Paginated list of exports
+          description: 'Paginated list of exports'
           schema:
             $ref: '#/definitions/ExportPaginated'
+        403:
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: Create an export
+      summary: 'Create an export'
       description: |
         Create a new export.
       tags:
@@ -2377,33 +2811,40 @@ paths:
             $ref: '#/definitions/ExportCreate'
       responses:
         201:
-          description: Export created
+          description: 'Export created'
           schema:
             $ref: '#/definitions/Export'
+        403:
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /exports/{uuid}/:
     x-resource: Exports
     get:
-      summary: Get export details
+      summary: 'Get export details'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Info about export
+          description: 'Info about export'
           schema:
             $ref: '#/definitions/Export'
-        404:
-          description: |
-            UUID parameter does not refer to an export or the user is not able to view the export it refers to
+        403:
+          description: 'Insufficient permissions or object not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update an export
+      summary: 'Update an export'
       tags:
         - Imagery
       parameters:
@@ -2415,41 +2856,45 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Update successful (no further processing needed)
+          description: 'Update successful (no further processing needed)'
         404:
           description: |
             The UUID parameter does not refer to a upload or the user does not have access to the upload it refers to
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete an export
+      summary: 'Delete an export'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Deletion successful (no content)
+          description: 'Deletion successful (no content)'
         404:
           description: |
             The UUID parameter does not refer to an export or the user does not have access to the export it refers to
           schema:
             $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /exports/{uuid}/definition:
     x-resource: Exports
     get:
-      summary: Get export details
+      summary: 'Get export details'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Info about export, in export job format
+          description: 'Info about export, in export job format'
           schema:
             $ref: '#/definitions/ExportDefinition'
         404:
@@ -2457,30 +2902,37 @@ paths:
             UUID parameter does not refer to an export or the user is not able to view the export it refers to
           schema:
             $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /exports/{uuid}/files:
     x-resource: Exports
     get:
-      summary: Get available files for the export
+      summary: 'Get available files for the export'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: List of files within an export
+          description: 'List of files within an export'
           schema:
-            type: "array"
+            type: array
             items:
-              type: "string"
-        404:
-          description: |
-            UUID parameter does not refer to an export or the user is not able to view the export it refers to or export was not finished successfully yet.
+              type: string
+        403:
+          description: 'Insufficient permissions, object does not exist, or export is not finished yet'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
   /exports/{uuid}/files/{filename}:
     x-resource: Exports
     get:
-      summary: Download a file from an export
+      summary: 'Download a file from an export'
       tags:
         - Imagery
       parameters:
@@ -2489,26 +2941,31 @@ paths:
           required: true
           in: path
           type: string
-          description: The filename of the file the user wishes to download. Filenames of an export need to first be fetched.
+          description: |
+            The filename of the file the user wishes to download. Filenames of an export need to first be fetched.
       responses:
         200:
-          description: The content of the reqested file
+          description: 'The content of the reqested file'
           schema:
             type: file
-        404:
+        403:
           description: |
-            UUID does not reference an export that exists, the user has access to, and has finished successfully. The filename may not exist
+            Export has not finished, file does not exist, or user has insufficient permissions to view.
           schema:
             $ref: '#/definitions/Error'
         503:
-          description: The request rate has been exceeded.
+          description: 'The request rate has been exceeded.'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /shapes/:
     x-resource: Projects
     get:
-      summary: Get shapes belonging to the current user
+      summary: 'Get shapes belonging to the current user'
       tags:
         - Imagery
       parameters:
@@ -2516,12 +2973,15 @@ paths:
         - $ref: '#/parameters/pageSize'
       responses:
         200:
-          description: GeoJSON feature collection containing paginated shapes
+          description: 'GeoJSON feature collection containing paginated shapes'
           schema:
             $ref: '#/definitions/ShapeFeatureCollectionPaginated'
-
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Create shapes belonging to the current user
+      summary: 'Create shapes belonging to the current user'
       tags:
         - Imagery
       parameters:
@@ -2535,15 +2995,19 @@ paths:
           description: GeoJSON shapes successfully created
           schema:
             $ref: '#/definitions/ShapeFeatureCollection'
+        400:
+          description: 'Invalid object'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error.
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /shapes/upload:
     x-resource: Projects
     post:
-      summary: Create shapes belonging to the current user using POSTed data
+      summary: 'Create shapes belonging to the current user using POSTed data'
       tags:
         - Imagery
       consumes:
@@ -2555,11 +3019,15 @@ paths:
           required: true
       responses:
         201:
-          description: GeoJSON shapes successfully created
+          description: 'GeoJSON shapes successfully created'
           schema:
             $ref: '#/definitions/ShapeFeatureCollection'
+        400:
+          description: 'Invalid shape structure'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error.
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
@@ -2573,12 +3041,20 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: GeoJSON feature containing one shape
+          description: 'GeoJSON feature containing one shape'
           schema:
             $ref: '#/definitions/ShapeFeature'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
     put:
-      summary: Update a specific shape
+      summary: 'Update a specific shape'
       tags:
         - Imagery
       parameters:
@@ -2590,41 +3066,59 @@ paths:
             $ref: '#/definitions/ShapeFeatureUpdate'
       responses:
         204:
-          description: No content, update successful
+          description: 'Update successful (No Content)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
     delete:
-      summary: Delete a shape
+      summary: 'Delete a shape'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Deletion successful.
-        404:
-          description: The UUID parameter does not refer to a shape or the user does not have access to it.
+          description: 'Deletion successful'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /shapes/{uuid}/permissions/:
     x-resource: Shapes
     get:
-      summary: List access control rules for this shape
+      summary: 'List access control rules for this shape'
       parameters:
         - $ref: '#/parameters/uuid'
       tags:
         - Permissions
       responses:
         200:
-          description: All access control rules for this shape
+          description: 'All access control rules for this shape'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
         403:
-          description: Insufficient permissions to list permissions on this shape
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     put:
-      summary: Replace permissions defined on this shape
+      summary: 'Replace permissions defined on this shape'
       tags:
         - Permissions
       parameters:
@@ -2638,13 +3132,21 @@ paths:
               $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rules replaced with response successfully
+          description: 'Access control rules replaced with response successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
-      summary: Add a new access control rule to this shape
+      summary: 'Add a new access control rule to this shape'
       tags:
         - Permissions
       parameters:
@@ -2656,15 +3158,23 @@ paths:
             $ref: '#/definitions/AccessControlRuleCreate'
       responses:
         200:
-          description: Access control rule appended successfully
+          description: 'Access control rule appended successfully'
           schema:
             type: array
             items:
               $ref: '#/definitions/AccessControlRule'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /licenses/:
     x-resource: Licenses
     get:
-      summary: Get a list of licenses
+      summary: 'Get a list of licenses'
       tags:
         - Imagery
         - Lab
@@ -2673,14 +3183,18 @@ paths:
         - $ref: '#/parameters/page'
       responses:
         200:
-          description: SUCCESS
+          description: 'Paginated licenses'
           schema:
             $ref: '#/definitions/LicensesPaginated'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
   /licenses/{licenseId}:
     x-resource: Licenses
     get:
-      summary: Get a license based on its id
+      summary: 'Get a license based on its id'
       tags:
         - Imagery
         - Lab
@@ -2688,14 +3202,18 @@ paths:
         - $ref: '#/parameters/licenseId'
       responses:
         200:
-          description: SUCCESS
+          description: 'License object'
           schema:
             $ref: '#/definitions/License'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
   /teams/:
     x-resource: Teams
     get:
-      summary: Get a list of teams
+      summary: 'List teams the user has permission to view'
       tags:
         - Users
       parameters:
@@ -2703,9 +3221,13 @@ paths:
         - $ref: '#/parameters/page'
       responses:
         200:
-          description: SUCCESS
+          description: 'Paginated teams'
           schema:
             $ref: '#/definitions/TeamsPaginated'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
     post:
       summary: Create a team
       tags:
@@ -2718,34 +3240,41 @@ paths:
             $ref: '#/definitions/TeamCreate'
       responses:
         201:
-          description: Get a newly created team
+          description: 'Team created' 
           schema:
             $ref: '#/definitions/Team'
+        403:
+          description: 'Insufficient permissions'
+          schema:
+            $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
   /teams/{uuid}:
     x-resource: Teams
     get:
-      summary: Get team details
+      summary: 'Get team details'
       tags:
         - Users
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         200:
-          description: Detail about a team
+          description: 'Detail about a team'
           schema:
             $ref: '#/definitions/Team'
-        404:
-          description: |
-            UUID parameter does not refer to a team or the user is not able to view the team it refers to
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: Update a team
+      summary: 'Update a team'
       tags:
         - Users
       parameters:
@@ -2757,31 +3286,33 @@ paths:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Update successful (no further processing needed)
+          description: 'Update successful (No content)'
           schema:
             $ref: '#/definitions/Team'
-        404:
-          description: |
-            UUID parameter does not refer to a team or the user is not able to view the team it refers to
+        403:
+          description: 'Insufficient permissions or object does not exist'
           schema:
             $ref: '#/definitions/Error'
         default:
-          description: Unexpected error
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: Delete a team
-      description: delete a team based on team id
+      summary: 'Delete a team'
+      description: 'Delete a team by id'
       tags:
         - Users
       parameters:
         - $ref: '#/parameters/uuid'
       responses:
         204:
-          description: Deletion successful (no content)
-        404:
-          description: |
-            UUID parameter does not refer to a team or the user is not able to view the team it refers to
+          description: 'Deletion successful (no content)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
 
@@ -2790,64 +3321,58 @@ parameters:
   orderingBase:
     name: ordering
     in: query
-    description: Field to order results; meaning of label varies based on endpoint
+    description: 'Field to order results; meaning of label varies based on endpoint'
     type: array
     collectionFormat: pipes
     items:
       type: string
       enum:
-        - createdAt,desc
-        - createdAt,asc
-        - modifiedAt,desc
-        - modifiedAt,asc
+        - 'createdAt,desc'
+        - 'createdAt,asc'
+        - 'modifiedAt,desc'
+        - 'modifiedAt,asc'
   AnnotationQualityCheck:
     name: AnnotationQualityCheck
-    description: Quality check on annotations
+    description: 'Quality check on annotations'
     in: query
     type: string
     required: true
     enum:
-      - PASS
-      - FAIL
-      - NEUTRAL
+      - 'PASS'
+      - 'FAIL'
+      - 'NEUTRAL'
   AnnotationLabel:
     name: AnnotationLabel
     in: query
-    description: name of a label
+    description: 'name of a label'
     type: string
   name:
     name: name
     in: query
-    description: name of a datasource to filter to
+    description: 'name of a datasource to filter to'
     type: string
   organization:
     name: organization
     in: query
-    description: UUID for organization to filter by
-    type: string
-    format: uuid
-  sceneId:
-    name: sceneId
-    in: query
-    description: UUID for scene
+    description: 'UUID for organization to filter by'
     type: string
     format: uuid
   projectId:
     name: projectId
     in: query
-    description: UUID for project
+    description: 'UUID for project'
     type: string
     format: uuid
   page:
     name: page
     in: query
-    description: Page of results to go to
+    description: 'Page of results to go to'
     type: number
     format: int32
   pageSize:
     name: pageSize
     in: query
-    description: Number of results per page in paginated response
+    description: 'Number of results per page in paginated response'
     type: number
     format: int32
   uuid:
@@ -2887,20 +3412,20 @@ parameters:
     type: string
   slugLabel:
     name: slugLabel
-    description: A url-safe slug label
+    description: 'A url-safe slug label'
     in: path
     required: true
     type: string
   forProjectId:
     name: forProjectId
-    description: UUID of the project to search for scenes to add
+    description: 'UUID of the project to search for scenes to add'
     in: query
     type: string
     format: uuid
     required: false
   minCloudCover:
     name: minCloudCover
-    description: Only return results with cloud cover greater than this number
+    description: 'Only return results with cloud cover greater than this number'
     in: query
     type: number
     minimum: 0
@@ -2908,65 +3433,65 @@ parameters:
     required: false
   maxCloudCover:
     name: maxCloudCover
-    description: Only return results with cloud cover less than this number
+    description: 'Only return results with cloud cover less than this number'
     in: query
     type: number
     required: false
   minAcquisitionDatetime:
     name: minAcquisitionDatetime
-    description: Only return results acquired after this datetime
+    description: 'Only return results acquired after this datetime'
     in: query
     type: string
     required: false
     format: datetime
   maxAcquisitionDatetime:
     name: maxAcquisitionDatetime
-    description: Only return results acquired before this datetime
+    description: 'Only return results acquired before this datetime'
     in: query
     type: string
     required: false
     format: datetime
   minCreateDatetime:
     name: minCreateDatetime
-    description: Only return results created after this datetime
+    description: 'Only return results created after this datetime'
     in: query
     type: string
     required: false
     format: datetime
   minSunElevation:
     name: minSunElevation
-    description: Only return results with sun elevation greater than this value
+    description: 'Only return results with sun elevation greater than this value'
     in: query
     type: number
     required: false
   maxSunElevation:
     name: maxSunElevation
-    description: Only return results with sun elevation less than this value
+    description: 'Only return results with sun elevation less than this value'
     in: query
     type: number
     required: false
   minSunAzimuth:
     name: minSunAzimuth
-    description: Only return results with sun elevation greater than this value
+    description: 'Only return results with sun elevation greater than this value'
     in: query
     type: number
     required: false
   maxSunAzimuth:
     name: maxSunAzimuth
-    description: Only return results with sun azium greater than this value
+    description: 'Only return results with sun azium greater than this value'
     in: query
     type: number
     required: false
   maxCreateDatetime:
     name: maxCreateDatetime
-    description: Only return results created before this datetime
+    description: 'Only return results created before this datetime'
     in: query
     type: string
     required: false
     format: datetime
   tags:
     name: tags
-    description: Only return results that contain these tags
+    description: 'Only return results that contain these tags'
     in: query
     type: array
     required: false
@@ -2974,7 +3499,7 @@ parameters:
       type: string
   datasource:
     name: datasource
-    description: Only return results belonging to this datasource
+    description: 'Only return results belonging to this datasource'
     in: query
     type: array
     required: false
@@ -2983,22 +3508,22 @@ parameters:
       format: uuid
   uploadStatus:
     name: uploadStatus
-    description: Status of upload
+    description: 'Status of upload'
     in: query
     type: string
     required: false
     enum:
-      - CREATED
-      - UPLOADING
-      - UPLOADED
-      - QUEUED
-      - PROCESSING
-      - COMPLETE
-      - FAILED
-      - ABORTED
+      - 'CREATED'
+      - 'UPLOADING'
+      - 'UPLOADED'
+      - 'QUEUED'
+      - 'PROCESSING'
+      - 'COMPLETE'
+      - 'FAILED'
+      - 'ABORTED'
   month:
     name: month
-    description: Only return results from this month
+    description: 'Only return results from this month'
     required: false
     in: query
     type: array
@@ -3009,44 +3534,44 @@ parameters:
       minimum: 1
   minDayOfMonth:
     name: minDayOfMonth
-    description: Only return results with acquisition day-of-month greater-than or equal-to this day
+    description: 'Only return results with acquisition day-of-month greater-than or equal-to this day'
     in: query
     type: number
   maxDayOfMonth:
     name: maxDayOfMonth
-    description: Only return results with acquisition day-of-month less-than than or equal-to this day
+    description: 'Only return results with acquisition day-of-month less-than or equal-to this day'
     in: query
     type: number
   orderingScene:
     name: ordering
     in: query
-    description: Fields to sort scenes by
+    description: 'Fields to sort scenes by'
     type: array
     collectionFormat: pipes
     items:
       type: string
       enum:
-        - createdAt,desc
-        - createdAt,asc
-        - modifiedAt,desc
-        - modifiedAt,asc
-        - organization,asc
-        - organization,desc
-        - datasource,asc
-        - datasource,desc
-        - month,asc
-        - month,desc
-        - createDatetime,asc
-        - createDatetime,desc
-        - acquisitionDatetime,asc
-        - acquisitionDatetime,desc
-        - sunAzimuth,asc
-        - sunAzimuth,desc
-        - cloudCover,asc
-        - cloudCover,desc
+        - 'createdAt,desc'
+        - 'createdAt,asc'
+        - 'modifiedAt,desc'
+        - 'modifiedAt,asc'
+        - 'organization,asc'
+        - 'organization,desc'
+        - 'datasource,asc'
+        - 'datasource,desc'
+        - 'month,asc'
+        - 'month,desc'
+        - 'createDatetime,asc'
+        - 'createDatetime,desc'
+        - 'acquisitionDatetime,asc'
+        - 'acquisitionDatetime,desc'
+        - 'sunAzimuth,asc'
+        - 'sunAzimuth,desc'
+        - 'cloudCover,asc'
+        - 'cloudCover,desc'
   toolTag:
     name: toolTag
-    description: Only return results that contain these tool tags
+    description: 'Only return results that contain these tool tags'
     in: query
     type: array
     required: false
@@ -3055,7 +3580,7 @@ parameters:
       format: uuid
   toolCategory:
     name: toolCategory
-    description: Only return results that satisfy this category
+    description: 'Only return results that satisfy this category'
     in: query
     type: array
     required: false
@@ -3063,86 +3588,86 @@ parameters:
       type: string
   minRating:
     name: minRating
-    description: Only return results greater than this rating
+    description: 'Only return results greater than this rating'
     in: query
     type: number
     required: false
   maxRating:
     name: maxRating
-    description: Only return results less than this rating
+    description: 'Only return results less than this rating'
     in: query
     type: number
     required: false
   search:
     name: search
-    description: Full text search string
+    description: 'Full text search string'
     in: query
     type: string
     required: false
   minRawDataBytes:
     name: minRawDataBytes
-    description: Only return images larger than this amount of bytes
+    description: 'Only return images larger than this amount of bytes'
     in: query
     type: integer
     required: false
   maxRawDataBytes:
     name: maxRawDataBytes
-    description: Only return images less than this amount of bytes
+    description: 'Only return images less than this amount of bytes'
     in: query
     type: integer
     required: false
   minResolution:
     name: minResolution
-    description: Only return objects that have elements greater than this resolution
+    description: 'Only return objects that have elements greater than this resolution'
     in: query
     type: number
     required: false
   maxResolution:
     name: maxResolution
-    description: Only return objects that have elements with a resolution less than this amount
+    description: 'Only return objects that have elements with a resolution less than this amount'
     in: query
     type: number
     required: false
   zoom:
     name: zoom
-    description: The zoom level used to split the bbox into a grid
+    description: 'The zoom level used to split the bbox into a grid'
     in: path
     type: number
     required: true
   column:
     name: column
-    description: column of tile requested
+    description: 'column of tile requested'
     in: path
     type: number
     required: true
   row:
     name: row
-    description: row of tile requested
+    description: 'row of tile requested'
     in: path
     type: number
     required: true
   bbox:
     name: bbox
-    description: Bounding box of the form "bbox=southwest_lng,southwest_lat,northeast_lng,northeast_lat". Delimit multiple with semicolons.
+    description: 'Bounding box of the form "bbox=southwest_lng,southwest_lat,northeast_lng,northeast_lat". Delimit multiple with semicolons.'
     in: query
     type: string
     required: false
   project:
     name: project
-    description: Project uuid to filter only
+    description: 'Project uuid to filter only'
     in: query
     type: string
     format: uuid
     required: false
   ingested:
     name: ingested
-    description: Filter by ingest status
+    description: 'Filter by ingest status'
     in: query
     type: boolean
     required: false
   ingestStatus:
     name: ingestStatus
-    description: Filter by specific ingest status
+    description: 'Filter by specific ingest status'
     in: query
     type: string
     required: false
@@ -3161,40 +3686,40 @@ parameters:
     required: false
   createdBy:
     name: createdBy
-    description: Filter by creator
+    description: 'Filter by creator'
     in: query
     type: string
     required: false
   owner:
     name: owner
-    description: Filter by object owner
+    description: 'Filter by object owner'
     in: query
     type: string
     required: false
   exportStatus:
     name: exportStatus
-    description: Status of export
+    description: 'Status of export'
     in: query
     type: string
     required: false
     enum:
-      - CREATED
-      - EXPORTING
-      - EXPORTED
-      - QUEUED
-      - PROCESSING
-      - COMPLETE
-      - FAILED
-      - ABORTED
+      - 'CREATED'
+      - 'EXPORTING'
+      - 'EXPORTED'
+      - 'QUEUED'
+      - 'PROCESSING'
+      - 'COMPLETE'
+      - 'FAILED'
+      - 'ABORTED'
   source:
     name: source
-    description: Feed source URI
+    description: 'Feed source URI'
     in: query
     type: string
     required: false
   licenseId:
     name: licenseId
-    description: id/shortName of a license
+    description: 'id/shortName of a license'
     in: path
     type: string
     required: true
@@ -3205,54 +3730,55 @@ definitions:
     properties:
       breakpoints:
         type: object
-        description: mapping from a tile cell value to associated color
+        description: 'Mapping from a tile cell value to associated color'
       scale:
         type: string
-        description: The type of scale to use (e.g. 'continuous', 'qualitative', 'diverging'); qualitative strings will contain a hex color (e.g. 'qualitative[#ff00ffff]')
+        description: |
+          The type of scale to use (e.g. 'continuous', 'qualitative', 'diverging'); qualitative strings will contain a hex color (e.g. 'qualitative[#ff00ffff]')
       clip:
         type: string
-        description: The clipping strategy to use (e.g. 'left', 'right', 'both', 'none')
+        description: "The clipping strategy to use (e.g. 'left', 'right', 'both', 'none')"
   BaseModel:
     type: object
     readOnly: true
     properties:
       id:
         type: string
-        description: unique identifier for object
+        description: 'unique identifier for object'
         format: uuid
   BaseCreate:
     type: object
     properties:
       owner:
         type: string
-        description: Optional during object creation, owner of an object
+        description: 'Optional during object creation, owner of an object'
   AccessControlRuleCreate:
     type: object
     properties:
       isActive:
         type: boolean
-        description: Whether this access control rule is active
+        description: 'Whether this access control rule is active'
       subjectType:
         type: string
-        description: The target this access control rule applies to
+        description: 'The target this access control rule applies to'
         enum:
-          - ALL
-          - PLATFORM
-          - ORGANIZATION
-          - TEAM
-          - USER
+          - 'ALL'
+          - 'PLATFORM'
+          - 'ORGANIZATION'
+          - 'TEAM'
+          - 'USER'
       subjectId:
         type: string
-        description: The id of the subject this access control rule applies to
+        description: 'The id of the subject this access control rule applies to'
       actionType:
         type: string
-        description: What this access control rule authorizes subjects to do
+        description: 'What this access control rule authorizes subjects to do'
         enum:
-          - VIEW
-          - EDIT
-          - DEACTIVATE
-          - DELETE
-          - ANNOTATE
+          - 'VIEW'
+          - 'EDIT'
+          - 'DEACTIVATE'
+          - 'DELETE'
+          - 'ANNOTATE'
   AccessControlRule:
     allOf:
       - $ref: '#/definitions/AccessControlRuleCreate'
@@ -3263,25 +3789,25 @@ definitions:
             format: uuid
           createdAt:
             type: string
-            description: timestamp of object creation
+            description: 'timestamp of object creation'
             format: date-time
           createdBy:
             type: string
-            description: user who created this object
+            description: 'user who created this object'
           objectType:
             type: string
-            description: type of object this access control rule applies to
+            description: 'type of object this access control rule applies to'
             enum:
-              - PROJECT
-              - SCENE
-              - DATASOURCE
-              - SHAPE
-              - WORKSPACE
-              - TEMPLATE
-              - ANALYSIS
+              - 'PROJECT'
+              - 'SCENE'
+              - 'DATASOURCE'
+              - 'SHAPE'
+              - 'WORKSPACE'
+              - 'TEMPLATE'
+              - 'ANALYSIS'
           objectId:
             type: string
-            description: id of the object this access control rule applies to
+            description: 'Id of the object this access control rule applies to'
             format: uuid
   MapToken:
     allOf:
@@ -3292,7 +3818,7 @@ definitions:
       properties:
         name:
           type: string
-          description: Human friendly label for map token
+          description: 'Human friendly label for map token'
         project:
           type: string
           format: UUID
@@ -3428,26 +3954,26 @@ definitions:
     properties:
       createdAt:
         type: string
-        description: timestamp of object creation
+        description: 'timestamp of object creation'
         format: date-time
       modifiedAt:
         type: string
-        description: timestamp of object modificiation
+        description: 'timestamp of object modificiation'
         format: date-time
   UserTrackingMixin:
     type: object
     properties:
       createdBy:
         type: string
-        description: User who created the object
+        description: 'User who created the object'
         readOnly: true
       modifiedBy:
         type: string
-        description: User who most recently modified the object
+        description: 'User who most recently modified the object'
         readOnly: true
       owner:
         type: string
-        description: User who owns the object
+        description: 'User who owns the object'
 
   User:
     allOf:
@@ -3459,23 +3985,24 @@ definitions:
       properties:
         id:
           type: string
-          description: User ID for Raster Foundry
+          description: 'User ID for Raster Foundry'
         role:
           type: string
-          description: User role in organization
+          description: 'User role in organization'
           enum:
-            - USER
-            - VIEWER
-            - OWNER
+            - 'USER'
+            - 'VIEWER'
+            - 'OWNER'
         dropboxCredential:
           type: string
-          description: Contains the user's dropbox credential if a connection has been configured
+          description: "Contains the user's dropbox credential if a connection has been configured"
         planetCredential:
           type: string
-          description: Contains the user's planet credential if a connection has been configured
+          description: "Contains the user's planet credential if a connection has been configured"
         emailNotifications:
           type: boolean
-          description: An opt-in (defaults to false) setting to recieve email notifications
+          description: 'An opt-in (defaults to false) setting to recieve email notifications'
+
   UserThin:
     type: object
     properties:
@@ -3485,6 +4012,15 @@ definitions:
         type: string
       profileImageUri:
         type: string
+
+  UserSearched:
+    allOf:
+    - $ref: '#/definitions/UserThin'
+    - type: object
+      properties:
+        email:
+          type: string
+
   UserWithOAuth:
     type: object
     properties:
@@ -3550,35 +4086,35 @@ definitions:
     properties:
       device_name:
         type: string
-        description: User created identifier to track refresh tokens
+        description: 'User created identifier to track refresh tokens'
       id:
         type: string
-        description: Auth0 provided identifier used to delete refresh tokens
+        description: 'Auth0 provided identifier used to delete refresh tokens'
   AuthToken:
     type: object
     properties:
       id_token:
         type: string
-        description: Token that can be used for authenticating API requests
+        description: 'Token that can be used for authenticating API requests'
       access_token:
         type: string
-        description: Token that can be used for authenticating API requests
+        description: 'Token that can be used for authenticating API requests'
       token_type:
         type: string
-        description: Type of token returned by using the refresh token
+        description: 'Type of token returned by using the refresh token'
   UserCreate:
     type: object
     properties:
       id:
         type: string
-        description: Auth0 ID for user
+        description: 'Auth0 ID for user'
       role:
         type: string
-        description: Role to create user with in the provided organization
+        description: 'Role to create user with in the provided organization'
         enum:
-          - USER
-          - VIEWER
-          - OWNER
+          - 'USER'
+          - 'VIEWER'
+          - 'OWNER'
   UserRole:
     type: object
     properties:
@@ -3587,8 +4123,8 @@ definitions:
       groupRole:
         type: string
         enum: 
-        - Admin
-        - Member
+        - 'ADMIN'
+        - 'MEMBER'
   UserGroupRole:
     type: object
     allOf:
@@ -3603,9 +4139,9 @@ definitions:
         groupType:
           type: string
           enum:
-          - Platform
-          - Organization
-          - Team
+          - 'PLATFORM'
+          - 'ORGANIZATION'
+          - 'TEAM'
         groupId:
           type: string
           format: uuid
@@ -3622,21 +4158,21 @@ definitions:
       count:
         type: integer
         format: int32
-        description: number of total objects matching query
+        description: 'number of total objects matching query'
       hasNext:
         type: boolean
-        description: True if more results can be fetched, otherwise false
+        description: 'True if more results can be fetched, otherwise false'
       hasPrevious:
         type: boolean
-        description: True if previous results can be fetched, otherwise false
+        description: 'True if previous results can be fetched, otherwise false'
       page:
         type: integer
         format: int32
-        description: Current page of paginated query results
+        description: 'Current page of paginated query results'
       pageSize:
         type: integer
         format: int32
-        description: Number of results per page
+        description: 'Number of results per page'
   UserWithRolePaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -3681,11 +4217,11 @@ definitions:
       id:
         type: string
         format: UUID
-        description: Platform Id
+        description: 'Platform Id'
         readOnly: true
       name:
         type: string
-        description: Platform display name
+        description: 'Platform display name'
       settings:
         type: object
       isActive:
@@ -3693,7 +4229,7 @@ definitions:
       defaultOrganizationId:
         type: string
         format: UUID
-        description: Default organization to add users to if one isn''t specified
+        description: "Default organization to add users to if one isn't specified"
     required:
       - id
       - name
@@ -3716,13 +4252,17 @@ definitions:
       properties:
         id:
           type: string
-          description: Organization
+          description: 'Organization Id'
         name:
           type: string
-          description: Display name for organization
+          description: 'Display name for organization'
         status:
           type: string
-          description: status of organization
+          description: 'status of organization'
+          enum:
+            - 'INACTIVE'
+            - 'REQUESTED'
+            - 'ACTIVE'
       required:
         - name
         - id
@@ -3752,15 +4292,15 @@ definitions:
       properties:
         createdBy:
           type: string
-          description: User who created the object
+          description: 'User who created the object'
           readOnly: true
         modifiedBy:
           type: string
-          description: User who most recently modified the object
+          description: 'User who most recently modified the object'
           readOnly: true
         organizationId:
           type: string
-          description: uuid for organization
+          description: 'uuid for organization'
         id:
           type: string
           format: UUID
@@ -3775,13 +4315,13 @@ definitions:
       organizationId:
         type: string
         format: UUID
-        description: uuid for organization
+        description: 'uuid for organization'
       name:
         type: string
-        description: name of a team
+        description: 'name of a team'
       settings:
         type: object
-        description: settings for a team, default to {}
+        description: 'settings for a team, default to {}'
 
 
   Geometry:
@@ -3799,7 +4339,7 @@ definitions:
             - MultiPolygon
             - Polygon
             - Point2D
-          description: the geometry type
+          description: 'the geometry type'
   Point2D:
       type: array
       maxItems: 2
@@ -3808,7 +4348,7 @@ definitions:
         type: number
   MultiPolygon:
       type: object
-      description: GeoJSON geometry
+      description: 'GeoJSON geometry'
       externalDocs:
         url: https://tools.ietf.org/html/rfc7946#section-3.1
       allOf:
@@ -3824,7 +4364,7 @@ definitions:
                     $ref: '#/definitions/Point2D'
   Polygon:
     type: object
-    description: GeoJSON geometry
+    description: 'GeoJSON geometry'
     externalDocs:
       url: https://tools.ietf.org/html/rfc7946#section-3.1
     allOf:
@@ -3838,11 +4378,11 @@ definitions:
                 $ref: '#/definitions/Point2D'
   Composite:
     type: object
-    description: mapping of bands to RGB
+    description: 'mapping of bands to RGB'
     properties:
       label:
         type: string
-        description: Human readable label for color composite to describe what it is useful for (e.g. natural color)
+        description: 'Human readable label for color composite to describe what it is useful for (e.g. natural color)'
       value:
         type: object
         properties:
@@ -3856,23 +4396,23 @@ definitions:
 
   DatasourceCreated:
     type: object
-    description: Grouping of imagery by creation source
+    description: 'Grouping of imagery by creation source'
     allOf:
       - type: object
         properties:
           visibility:
             type: string
-            description: Level of restriction on viewing
+            description: 'Level of restriction on viewing'
             enum:
-              - PUBLIC
-              - ORGANIZATION
-              - PRIVATE
+              - 'PUBLIC'
+              - 'ORGANIZATION'
+              - 'PRIVATE'
           name:
             type: string
-            description: human label name for datasource
+            description: 'human label name for datasource'
           extras:
             type: object
-            description: additional related information for a datasource
+            description: 'additional related information for a datasource'
           composites:
             $ref: '#/definitions/Composite'
 
@@ -3885,15 +4425,15 @@ definitions:
 
   DatasourceThin:
     type: object
-    description: A datasource with a reduced set of fields
+    description: 'A datasource with a reduced set of fields'
     properties:
       name:
         type: string
-        description: The name of this datasource
+        description: 'The name of this datasource'
       id:
         type: string
         format: uuid
-        description: The id of this datasource
+        description: 'The id of this datasource'
 
   DatasourcePaginated:
     allOf:
@@ -3906,20 +4446,20 @@ definitions:
             $ref: '#/definitions/Datasource'
   License:
     type: object
-    description: A record of license
+    description: 'A record of license'
     properties:
       name:
         type: string
-        description: Name of a license
+        description: 'Name of a license'
       osiApproved:
         type: boolean
-        description: If a license is OSI approved
+        description: 'If a license is OSI approved'
       shortName:
         type: string
-        description: Short name of a license
+        description: 'Short name of a license'
       url:
         type: string
-        description: URL to details of a license
+        description: 'URL to details of a license'
 
   LicensesPaginated:
     allOf:
@@ -3940,23 +4480,23 @@ definitions:
         properties:
           name:
             type: string
-            description: The display name of the project
+            description: 'The display name of the project'
           ingestLocation:
             type: string
-            description: Where scene is ingested (pyramided/tiled)
+            description: 'Where scene is ingested (pyramided/tiled)'
           ingestSizeBytes:
             type: integer
-            description: Size of ingested data in bytes.
+            description: 'Size of ingested data in bytes.'
           visibility:
             type: string
-            description: Level of restriction on viewing
+            description: 'Level of restriction on viewing'
             enum:
-              - PUBLIC
-              - ORGANIZATION
-              - PRIVATE
+              - 'PUBLIC'
+              - 'ORGANIZATION'
+              - 'PRIVATE'
           tags:
             type: array
-            description: Tags associated with image
+            description: 'Tags associated with image'
             items:
               type: string
           images:
@@ -3968,17 +4508,12 @@ definitions:
             items:
               $ref: '#/definitions/Thumbnail'
           datasource:
-            type: object
-            schema:
-              $ref: '#/definitions/DatasourceThin'
-            description: Data source scene originated from
+            $ref: '#/definitions/DatasourceThin'
           dataFootprint:
             $ref: '#/definitions/MultiPolygon'
-            description: polygon for which this scene has data
             readOnly: true
           tileFootprint:
             $ref: '#/definitions/MultiPolygon'
-            description: polygon for tile
             readOnly: true
           sceneMetadata:
             type: object
@@ -3998,10 +4533,10 @@ definitions:
             $ref: '#/definitions/StatusFields'
           sceneType:
             type: string
-            description: How to produce tiles of this scene
+            description: 'How to produce tiles of this scene'
             enum:
-              - AVRO
-              - COG
+              - 'AVRO'
+              - 'COG'
 
   FilterFields:
     type: object
@@ -4009,50 +4544,50 @@ definitions:
       cloudCover:
         type: number
         format: float32
-        description: Proportion of cloud coverage for scene
+        description: 'Proportion of cloud coverage for scene'
       acquisitionDate:
         type: string
         format: datetime
-        description: Date scene was acquired from instrument (e.g. satellite, drone)
+        description: 'Date scene was acquired from instrument (e.g. satellite, drone)'
       sunAzimuth:
         type: number
         format: float32
-        description: Azimuth of the sun
+        description: 'Azimuth of the sun'
       sunElevation:
         type: number
         format: float32
-        description: Elevation of the sun
+        description: 'Elevation of the sun'
 
   StatusFields:
     type: object
     properties:
       thumbnailStatus:
         type: string
-        description: status of thumbnail generation
+        description: 'status of thumbnail generation'
         enum:
-          - SUCCESS
-          - FAILURE
-          - PARTIALFAILURE
-          - QUEUED
-          - PROCESSING
+          - 'SUCCESS'
+          - 'FAILURE'
+          - 'PARTIALFAILURE'
+          - 'QUEUED'
+          - 'PROCESSING'
       footprintStatus:
         type: string
-        description: status of footprint generation
+        description: 'status of footprint generation'
         enum:
-          - SUCCESS
-          - FAILURE
-          - PARTIALFAILURE
-          - QUEUED
-          - PROCESSING
+          - 'SUCCESS'
+          - 'FAILURE'
+          - 'PARTIALFAILURE'
+          - 'QUEUED'
+          - 'PROCESSING'
       ingestStatus:
         type: string
-        description: status of ingest
+        description: 'status of ingest'
         enum:
-          - NOTINGESTED
-          - TOBEINGESTED
-          - INGESTING
-          - INGESTED
-          - FAILED
+          - 'NOTINGESTED'
+          - 'TOBEINGESTED'
+          - 'INGESTING'
+          - 'INGESTED'
+          - 'FAILED'
 
   SceneGrid:
     type: array
@@ -4069,41 +4604,41 @@ definitions:
       properties:
         name:
           type: string
-          description: The display name of the project
+          description: 'The display name of the project'
         slugLabel:
           type: string
-          description: URL-safe version of name
+          description: 'URL-safe version of name'
           readOnly: true
         description:
           type: string
-          description: Long-form description of the project
+          description: 'Long-form description of the project'
         visibility:
           type: string
-          description: Level of restriction on viewing
+          description: 'Level of restriction on viewing'
           enum:
-            - PUBLIC
-            - ORGANIZATION
-            - PRIVATE
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'
         tileVisibility:
           type: string
-          description: Level of restriction on viewing
+          description: 'Level of restriction on viewing'
           enum:
-            - PUBLIC
-            - ORGANIZATION
-            - PRIVATE
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'
         tags:
           type: array
           items:
             type: string
         extent:
           type: object
-          description: GeoJSON Geometry of project extent
+          description: 'GeoJSON Geometry of project extent'
         manualOrder:
           type: boolean
-          description: Is true if project scenes are manually ordered
+          description: 'Is true if project scenes are manually ordered'
         isAOIProject:
           type: boolean
-          description: Is true if project is an area-of-interest project
+          description: 'Is true if project is an area-of-interest project'
   Image:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -4112,36 +4647,36 @@ definitions:
       properties:
         visibility:
           type: string
-          description: Level of restriction on viewing
+          description: 'Level of restriction on viewing'
           enum:
-            - PUBLIC
-            - ORGANIZATION
-            - PRIVATE
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'
         filename:
           type: string
-          description: Name of the image file
+          description: 'Name of the image file'
         resolutionMeters:
           type: number
-          description: Size of pixel in meters
+          description: 'Size of pixel in meters'
         sourceUri:
           type: string
-          description: URI to original source. This should include a protocol-like prefix to identify where it is located http://, s3://, etc.
+          description: 'URI to original source. This should include a protocol-like prefix to identify where it is located http://, s3://, etc.'
         rawDataBytes:
           type: integer
           format: int64
-          description: Size of original uploaded imagery in bytes
+          description: 'Size of original uploaded imagery in bytes'
         bands:
           type: array
-          description: list of band types for image; a single band denotes a single band image, multiple bands should be listed in order (e.g if it is an RGB tiff then bands should be [red, green blue])
+          description: 'list of band types for image; a single band denotes a single band image, multiple bands should be listed in order (e.g if it is an RGB tiff then bands should be [red, green blue])'
           items:
             $ref: '#/definitions/Band'
         scene:
           type: string
           format: uuid
-          description: Scene that image is associated with
+          description: 'Scene that image is associated with'
         image_metadata:
           type: object
-          description: Metadata about this image
+          description: 'Metadata about this image'
         metadataFiles:
           type: array
           items:
@@ -4160,36 +4695,36 @@ definitions:
       properties:
         visibility:
           type: string
-          description: Level of restriction on viewing
+          description: 'Level of restriction on viewing'
           enum:
-            - PUBLIC
-            - ORGANIZATION
-            - PRIVATE
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'
         filename:
           type: string
-          description: Name of the image file
+          description: 'Name of the image file'
         resolutionMeters:
           type: number
-          description: Size of pixel in meters
+          description: 'Size of pixel in meters'
         sourceUri:
           type: string
-          description: URI to original source. This should include a protocol-like prefix to identify where it is located http://, s3://, etc.
+          description: 'URI to original source. This should include a protocol-like prefix to identify where it is located http://, s3://, etc.'
         rawDataBytes:
           type: integer
           format: int64
-          description: Size of original uploaded imagery in bytes
+          description: 'Size of original uploaded imagery in bytes'
         bands:
           type: array
-          description: list of band types for image; a single band denotes a single band image, multiple bands should be listed in order (e.g if it is an RGB tiff then bands should be [red, green blue])
+          description: 'list of band types for image; a single band denotes a single band image, multiple bands should be listed in order (e.g if it is an RGB tiff then bands should be [red, green blue])'
           items:
             $ref: '#/definitions/Band'
         scene:
           type: string
           format: uuid
-          description: Scene that image is associated with
+          description: 'Scene that image is associated with'
         image_metadata:
           type: object
-          description: Metadata about this image
+          description: 'Metadata about this image'
         metadataFiles:
           type: array
           items:
@@ -4199,7 +4734,7 @@ definitions:
             images in a scene (e.g. relevant .mtl files or .xml)
         downloadUri:
           type: string
-          description: URI to downloadable resource. This is not always the same as `sourceUri`.
+          description: 'URI to downloadable resource. This is not always the same as `sourceUri`.'
       required:
         - filename
         - sourceUri
@@ -4241,10 +4776,10 @@ definitions:
         format: UUID
       name:
         type: string
-        description: String representation of band name
+        description: 'String representation of band name'
       number:
         type: integer
-        description: Band number for image
+        description: 'Band number for image'
       wavelength:
         type: array
         items:
@@ -4258,26 +4793,26 @@ definitions:
         widthPx:
           type: integer
           format: int32
-          description: The width of the thumbnail, in pixels
+          description: 'The width of the thumbnail, in pixels'
         sceneId:
           type: string
           format: uuid
-          description: Scene that image is associated with
+          description: 'Scene that image is associated with'
         heightPx:
           type: integer
           format: int32
-          description: The height of the thumbnail, in pixels
+          description: 'The height of the thumbnail, in pixels'
         thumbnailSize:
           type: string
-          description: Summary of size
+          description: 'Summary of size'
           enum:
-            - SMALL
-            - LARGE
-            - SQUARE
+            - 'SMALL'
+            - 'LARGE'
+            - 'SQUARE'
         url:
           type: string
           format: uri
-          description: A client-accessible URL pointing to the image file
+          description: 'A client-accessible URL pointing to the image file'
   ThumbnailPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -4295,47 +4830,47 @@ definitions:
       properties:
         title:
           type: string
-          description: Title of tool displayed to users
+          description: 'Title of tool displayed to users'
         description:
           type: string
           description: |
             A long description of the tool, including is use-cases,
             purpose, and any potential references
         organization:
-          description: The owning organization of the Tool
+          description: 'The owning organization of the Tool'
           items:
             $ref: '#/definitions/Organization'
         requirements:
           type: string
-          description: A brief description of requirements, including any relevant band requirements
+          description: 'A brief description of requirements, including any relevant band requirements'
         tags:
           type: array
-          description: Tool tags associated with a tool
+          description: 'Tool tags associated with a tool'
           items:
             type: string
         categories:
           type: array
-          description: Category of geoprocessing tool
+          description: 'Category of geoprocessing tool'
           items:
             type: string
         license:
           type: string
-          description: Usage license of tool
+          description: 'Usage license of tool'
         compatibleDatasources:
           type: array
-          description: Datasources that can be used with this geoprocessing tool
+          description: 'Datasources that can be used with this geoprocessing tool'
           items:
             type: string
         stars:
           type: number
-          description: User rating of geoprocessing tool
+          description: 'User rating of geoprocessing tool'
         visibility:
           type: string
-          description: Level of restriction on viewing
+          description: 'Level of restriction on viewing'
           enum:
-            - PUBLIC
-            - ORGANIZATION
-            - PRIVATE
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'
   ToolPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -4353,7 +4888,7 @@ definitions:
       properties:
         label:
           type: string
-          description: User displayed label
+          description: 'User displayed label'
   ToolTagPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -4370,10 +4905,10 @@ definitions:
       properties:
         category:
           type: string
-          description: User displayed label for category
+          description: 'User displayed label for category'
         slugLabel:
           type: string
-          description: Slug label for use in urls
+          description: 'Slug label for use in urls'
   ToolCategoryPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -4391,16 +4926,16 @@ definitions:
       properties:
         execution_parameters:
           type: object
-          description: Parameters for running the tool
+          description: 'Parameters for running the tool'
         name:
           type: string
         visibility:
           type: string
-          description: Level of restriction on viewing
+          description: 'Level of restriction on viewing'
           enum:
-            - PUBLIC
-            - ORGANIZATION
-            - PRIVATE
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'
 
   ToolRunPaginated:
     allOf:
@@ -4423,7 +4958,7 @@ definitions:
 
   OrgParams:
     type: object
-    description: Organization parameters to filter scenes
+    description: 'Organization parameters to filter scenes'
     properties:
       organizations:
         type: array
@@ -4433,20 +4968,18 @@ definitions:
 
   UserParams:
     type: object
-    description: User parameters to filter scenes
+    description: 'User parameters to filter scenes'
     properties:
       createdBy:
         type: string
       modifiedBy:
         type: string
       owner:
-        oneOf:
-          - type: string
-          - $ref: '#/definitions/UserThin'
+        type: string
 
   TimestampParams:
     type: object
-    description: Timestamp parameters to filter scenes
+    description: 'Timestamp parameters to filter scenes'
     properties:
       minCreateDatetime:
         type: string
@@ -4468,54 +5001,54 @@ definitions:
       properties:
         uploadStatus:
           type: string
-          description: Status of upload
+          description: 'Status of upload'
           enum:
-            - CREATED
-            - UPLOADING
-            - UPLOADED
-            - QUEUED
-            - PROCESSING
-            - COMPLETE
-            - FAILED
-            - ABORTED
+            - 'CREATED'
+            - 'UPLOADING'
+            - 'UPLOADED'
+            - 'QUEUED'
+            - 'PROCESSING'
+            - 'COMPLETE'
+            - 'FAILED'
+            - 'ABORTED'
         files:
           type: array
           items:
             type: string
-          description: An array of strings of file locations. If a source is provided, this can be empty
+          description: 'An array of strings of file locations. If a source is provided, this can be empty'
         uploadType:
           type: string
-          description: Source of files and uploads
+          description: 'Source of files and uploads'
           enum:
-            - DROPBOX
-            - S3
-            - LOCAL
-            - PLANET
-            - MODIS_USGS
+            - 'DROPBOX'
+            - 'S3'
+            - 'LOCAL'
+            - 'PLANET'
+            - 'MODIS_USGS'
         fileType:
           type: string
-          description: type of data being uploaded, limited to two options right now
+          description: 'type of data being uploaded, limited to two options right now'
           enum:
-            - GEOTIFF
-            - GEOTIFF_WITH_METADATA
+            - 'GEOTIFF'
+            - 'GEOTIFF_WITH_METADATA'
         datasource:
           type: string
-          description: datasource of tiffs being uploaded
+          description: 'datasource of tiffs being uploaded'
           format: uuid
         visibility:
           type: string
-          description: Level of restriction on viewing
+          description: 'Level of restriction on viewing'
           enum:
-            - PUBLIC
-            - ORGANIZATION
-            - PRIVATE
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'
         projectId:
           type: string
           format: uuid
-          description: during the import process, add scenes to a project if specified
+          description: 'during the import process, add scenes to a project if specified'
         source:
           type: string
-          description: for uploads of type S3 and Dropbox, the location of the files to import. If files are specified, this field is ignored
+          description: 'for uploads of type S3 and Dropbox, the location of the files to import. If files are specified, this field is ignored'
         sceneMetadata:
           $ref: '#/definitions/UploadMetadata'
   Upload:
@@ -4570,7 +5103,7 @@ definitions:
         type: string
   SceneParams:
     type: object
-    description: scene params
+    description: 'scene params'
     properties:
       maxCloudCover:
         type: number
@@ -4624,15 +5157,15 @@ definitions:
       ingestStatus:
         type: string
         enum:
-          - NOTINGESTED
-          - TOBEINGESTED
-          - INGESTING
-          - INGESTED
-          - FAILED
+          - 'NOTINGESTED'
+          - 'TOBEINGESTED'
+          - 'INGESTING'
+          - 'INGESTED'
+          - 'FAILED'
 
   ImageParams:
     type: object
-    description: image params
+    description: 'image params'
     properties:
       minRawDataBytes:
         type: number
@@ -4654,7 +5187,7 @@ definitions:
 
   CombinedSceneQueryParams:
     type: object
-    description: Combined query parameters for filtering scenes
+    description: 'Combined query parameters for filtering scenes'
     properties:
       orgParams:
         $ref: '#/definitions/OrgParams'
@@ -4669,7 +5202,7 @@ definitions:
 
   SceneCorrectionParam:
     type: object
-    description: A paired scene ID and color correction parameter list
+    description: 'A paired scene ID and color correction parameter list'
     properties:
       sceneId:
         type: string
@@ -4679,7 +5212,7 @@ definitions:
 
   CombinedSceneCorrectionParams:
     type: array
-    description: Combined color correction parameters for multiple scenes
+    description: 'Combined color correction parameters for multiple scenes'
     items:
       $ref: '#/definitions/SceneCorrectionParam'
   ExportCreate:
@@ -4698,34 +5231,34 @@ definitions:
             format: uuid
         exportStatus:
           type: string
-          description: Status of export
+          description: 'Status of export'
           enum:
-            - CREATED
-            - EXPORTING
-            - EXPORTED
-            - QUEUED
-            - PROCESSING
-            - COMPLETE
-            - FAILED
-            - ABORTED
+            - 'CREATED'
+            - 'EXPORTING'
+            - 'EXPORTED'
+            - 'QUEUED'
+            - 'PROCESSING'
+            - 'COMPLETE'
+            - 'FAILED'
+            - 'ABORTED'
         exportType:
           type: string
-          description: Source of exports
+          description: 'Source of exports'
           enum:
-            - DROPBOX
-            - S3
-            - LOCAL
+            - 'DROPBOX'
+            - 'S3'
+            - 'LOCAL'
         visibility:
           type: string
-          description: Level of restriction on viewing
+          description: 'Level of restriction on viewing'
           enum:
-            - PUBLIC
-            - ORGANIZATION
-            - PRIVATE
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'
         toolRunId:
           type: string
           format: uuid
-          description: Optional id of a ToolRun. Specifying this will perform an RDD-AST-based export job.
+          description: 'Optional id of a ToolRun. Specifying this will perform an RDD-AST-based export job.'
         exportOptions:
           $ref: '#/definitions/ExportOptions'
   Export:
@@ -4737,16 +5270,16 @@ definitions:
       properties:
         exportStatus:
           type: string
-          description: Status of export
+          description: 'Status of export'
           enum:
-            - CREATED
-            - EXPORTING
-            - EXPORTED
-            - QUEUED
-            - PROCESSING
-            - COMPLETE
-            - FAILED
-            - ABORTED
+            - 'CREATED'
+            - 'EXPORTING'
+            - 'EXPORTED'
+            - 'QUEUED'
+            - 'PROCESSING'
+            - 'COMPLETE'
+            - 'FAILED'
+            - 'ABORTED'
   ExportPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'
@@ -4758,46 +5291,46 @@ definitions:
             $ref: '#/definitions/Export'
   ExportOptions:
     type: object
-    description: export params
+    description: 'export params'
     properties:
       operation:
         type: string
-        description: currently a not supported flag, describes a render operation, "id" by defaut.
+        description: 'currently a not supported flag, describes a render operation, "id" by defaut.'
       bands:
         type: array
-        description: bands in the exported geotiffs
+        description: 'bands in the exported geotiffs'
         items:
           type: integer
       rasterSize:
         type: integer
-        description: desired tiff size after export
+        description: 'desired tiff size after export'
       crs:
         type: integer
-        description: epsg projection code
+        description: 'epsg projection code'
       mask:
         type: object
-        description: GeoJSON multipolygon
+        description: 'GeoJSON multipolygon'
       stitch:
         type: boolean
-        description: stitch tiles into a single geotiff if possible
+        description: 'stitch tiles into a single geotiff if possible'
       crop:
         type: boolean
-        description: crop stitched raster by provided mask if possible
+        description: 'crop stitched raster by provided mask if possible'
       raw:
         type: boolean
-        description: make a raw export skipping all color correction steps
+        description: 'make a raw export skipping all color correction steps'
   ExportDefinition:
     type: object
     properties:
       exportStatus:
         type: string
-        description: Status of export
+        description: 'Status of export'
         enum:
-          - NOTEXPORTED
-          - TOBEEXPORTED
-          - EXPORTING
-          - EXPORTED
-          - FAILED
+          - 'NOTEXPORTED'
+          - 'TOBEEXPORTED'
+          - 'EXPORTING'
+          - 'EXPORTED'
+          - 'FAILED'
       input:
         $ref: '#/definitions/InputExportDefinition'
       output:
@@ -4813,7 +5346,7 @@ definitions:
         description: "required resolution (currently it's zoom level)"
       mask:
         type: object
-        description: GeoJSON multipolygon
+        description: 'GeoJSON multipolygon'
       layers:
         type: object
         properties:
@@ -4830,40 +5363,40 @@ definitions:
     properties:
       rasterSize:
         type: integer
-        description: desired tiff size after export
+        description: 'desired tiff size after export'
       crs:
         type: integer
-        description: epsg projection code
+        description: 'epsg projection code'
       stitch:
         type: boolean
-        description: stitch tiles into a single geotiff if possible
+        description: 'stitch tiles into a single geotiff if possible'
       crop:
         type: boolean
-        description: crop stitched raster by provided mask if possible
+        description: 'crop stitched raster by provided mask if possible'
       source:
         type: string
         format: uuid
-        description: output export path
+        description: 'output export path'
       render:
         $ref: '#/definitions/Render'
       dropboxCredential:
         type: string
-        description: Dropbox token
+        description: 'Dropbox token'
   Render:
     type: object
     properties:
       operation:
         type: string
-        description: currently useless Field
+        description: 'currently useless Field'
       bands:
         type: array
-        description: bands in the exported geotiffs
+        description: 'bands in the exported geotiffs'
         items:
           type: integer
 
   BulkAcceptParams:
     type: object
-    description: bulk accept params
+    description: 'bulk accept params'
     properties:
       sceneIds:
         type: array
@@ -4895,10 +5428,10 @@ definitions:
           quality:
             type: string
             enum:
-              - YES
-              - NO
-              - MISS
-              - MATCH
+              - 'YES'
+              - 'NO'
+              - 'MISS'
+              - 'MATCH'
           projectId:
             type: string
             format: uuid
@@ -4925,10 +5458,10 @@ definitions:
           quality:
             type: string
             enum:
-              - YES
-              - NO
-              - MISS
-              - MATCH
+              - 'YES'
+              - 'NO'
+              - 'MISS'
+              - 'MATCH'
       geometry:
         $ref: "#/definitions/Geometry"
 
@@ -4954,10 +5487,10 @@ definitions:
           quality:
             type: string
             enum:
-              - YES
-              - NO
-              - MISS
-              - MATCH
+              - 'YES'
+              - 'NO'
+              - 'MISS'
+              - 'MATCH'
       geometry:
         $ref: "#/definitions/Geometry"
 

--- a/spec.yml
+++ b/spec.yml
@@ -91,6 +91,9 @@ x-resources:
   - name: Teams
     description: |
       Teams represent groups of users within (and across) organizations. Each team belongs to one organization. A user can be a member of any number of teams.
+  - name: Admin
+    description: |
+      Platforms, Organizations, and Teams can be used to manage users and visibility of projects, analyses, and scenes. Most of these functions will only be available to uses who are administrating groups.
 
 
 tags:
@@ -106,6 +109,8 @@ tags:
     description: 'Statistical metadata about geospatial data'
   - name: Permissions
     description: 'Resources relating to object-level access'
+  - name: Admin
+    description: 'Resources related to administration'
 
 paths:
   /users/dropbox-setup/:
@@ -355,11 +360,11 @@ paths:
             $ref: '#/definitions/Error'
 
   /platforms/:
-    x-resource: Platforms
+    x-resource: Admin
     get:
       summary: 'Get a list of platforms'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/pageSize'
@@ -375,7 +380,7 @@ paths:
     post:
       summary: 'Create a platform'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - name: Platform
           in: body
@@ -391,11 +396,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/:
-    x-resource: Platforms
+    x-resource: Admin
     get:
       summary: 'Get a platform'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
       responses: 
@@ -414,7 +419,7 @@ paths:
     put:
       summary: 'Update a platform'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - name: Platform
@@ -435,7 +440,7 @@ paths:
     delete:
       summary: 'Delete a platform'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
       responses:
@@ -447,11 +452,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/members/:
-    x-resource: Platforms
+    x-resource: Admin
     get:
       summary: 'Get a list of users for the platform. Platform admin only'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/page'
@@ -469,7 +474,7 @@ paths:
     post:
       summary: 'Move a user to the platform'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - name: userRole
@@ -489,11 +494,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/:
-    x-resource: Platforms
+    x-resource: Admin
     get:
       summary: 'List platform organizations. Platform admin only.'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/page'
@@ -510,7 +515,7 @@ paths:
     post:
       summary: 'Create an Organization.'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - name: Organization
@@ -528,11 +533,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/:
-    x-resource: Platforms
+    x-resource: Admin
     get:
       summary: 'Fetch platform organization'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -552,7 +557,7 @@ paths:
     put:
       summary: 'Update platform organization'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -575,7 +580,7 @@ paths:
     delete:
       summary: 'Deactivate platform organization'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -592,11 +597,11 @@ paths:
             $ref: '#/definitions/Error'
 
   /platforms/{platformID}/organizations/{organizationID}/members/:
-    x-resource: Platforms
+    x-resource: Admin
     get:
       summary: 'Fetch organization member list. Organization admin only'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -615,7 +620,7 @@ paths:
     post:
       summary: 'Move a user to the organization'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -636,11 +641,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/teams/:
-    x-resource: Platforms
+    x-resource: Admin
     get:
       summary: 'Fetch organization teams'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -658,7 +663,7 @@ paths:
     post:
       summary: 'Create organization team'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -677,11 +682,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/teams/{teamID}/:
-    x-resource: Platforms
+    x-resource: Admin
     get:
       summary: 'Fetch team'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -702,7 +707,7 @@ paths:
     put:
       summary: 'Update team'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -722,7 +727,7 @@ paths:
     delete:
       summary: 'Delete team'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -735,11 +740,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/teams/{teamID}/members/:
-    x-resource: Platforms
+    x-resource: Admin
     get:
       summary: 'Fetch team members'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -759,7 +764,7 @@ paths:
     post:
       summary: 'Add team member'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'
@@ -781,11 +786,11 @@ paths:
           schema:
             $ref: '#/definitions/Error'
   /platforms/{platformID}/organizations/{organizationID}/teams/{teamID}/members/{userID}:
-    x-resource: Platforms
+    x-resource: Admin
     delete:
       summary: 'Remove team member'
       tags:
-        - Platforms
+        - Admin
       parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/organizationID'


### PR DESCRIPTION
### Overview
- Update descriptions on platforms/{}/organizations and platforms/{}/members to
reflect permissions required
- Fixed some inconsistent quoting that was causing issues. I defaulted to quoting any text that will eventually be shown to the user (descriptions, summaries, enums)
- Added some missing responses / made them more consistent
- Fixed typos

### Testing/validation
- Verify that swagger editor v2 doesn't complain https://editor2.swagger.io/#!/
- Verify that administration endpoints now show up in the docsite
  To do this locally, you can create a soft link from the docsite's `/assets/spec.yml` to your api spec repository's spec file, and run it locally by using `yarn start`
Closes https://github.com/raster-foundry/raster-foundry-api-spec/issues/23
Closes https://github.com/azavea/raster-foundry-platform/issues/367