### PR TITLE
Deploy to staging bucket in CI when merging to develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ deploy:
     skip_cleanup: true
     on:
       repo: raster-foundry/raster-foundry-api-spec
-      branch: develop
+      branch: feature/jrb/push-to-staging
     
   - provider: s3
     access_key_id: $AWS_ACCESS_KEY_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ deploy:
     skip_cleanup: true
     on:
       repo: raster-foundry/raster-foundry-api-spec
-      branch: feature/jrb/push-to-staging
+      branch: develop
     
   - provider: s3
     access_key_id: $AWS_ACCESS_KEY_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,24 @@ services: docker
 script:
 - "./scripts/cibuild"
 deploy:
-  provider: s3
-  access_key_id: $AWS_ACCESS_KEY_ID
-  secret_access_key: $AWS_SECRET_ACCESS_KEY
-  bucket: rasterfoundry-production-docs-site-us-east-1
-  upload-dir: spec
-  local_dir: spec
-  skip_cleanup: true
-  on:
-    repo: raster-foundry/raster-foundry-api-spec
-    tags: true
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    bucket: rasterfoundry-staging-docs-site-us-east-1
+    upload-dir: spec
+    local_dir: spec
+    skip_cleanup: true
+    on:
+      repo: raster-foundry/raster-foundry-api-spec
+      branch: develop
     
+  - provider: s3
+    access_key_id: $AWS_ACCESS_KEY_ID
+    secret_access_key: $AWS_SECRET_ACCESS_KEY
+    bucket: rasterfoundry-production-docs-site-us-east-1
+    upload-dir: spec
+    local_dir: spec
+    skip_cleanup: true
+    on:
+      repo: raster-foundry/raster-foundry-api-spec
+      tags: true


### PR DESCRIPTION
## Overview

Deploy to `rasterfoundry-staging-docs-site-us-east-1` bucket in CI when merging to `develop`.

Fixes #28 

## Notes

I updated the scope of the IAM policy attached to the IAM user:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": "s3:PutObject",
            "Resource": [
                "arn:aws:s3:::rasterfoundry-production-docs-site-us-east-1/spec/*",
                "arn:aws:s3:::rasterfoundry-staging-docs-site-us-east-1/spec/*"
            ]
        }
    ]
}
```

## Testing

See Travis CI build: https://travis-ci.com/raster-foundry/raster-foundry-api-spec/builds/77898651