### PR TITLE
Remove ingestSizeBytes from scenes

### DIFF
--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -4642,9 +4642,6 @@ definitions:
           ingestLocation:
             type: string
             description: 'Where scene is ingested (pyramided/tiled)'
-          ingestSizeBytes:
-            type: integer
-            description: 'Size of ingested data in bytes.'
           visibility:
             type: string
             description: 'Level of restriction on viewing'


### PR DESCRIPTION
This PR removes ingestSizeBytes from the spec to reflect changes in
raster-foundry/raster-foundry#3784