### PR TITLE
Update responses for adding scenes to projects

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -1873,7 +1873,7 @@ paths:
               type: string
               format: uuid
       responses:
-        201:
+        200:
           description: 'List of scenes added to project'
           schema:
             type: array
@@ -1903,8 +1903,12 @@ paths:
               type: string
               format: uuid
       responses:
-        204:
-          description: 'No content, update successful'
+        200:
+          description: 'Scenes in this project'
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Scene'
         403:
           description: 'Insufficient permissions or object does not exist'
           schema:

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -1904,7 +1904,7 @@ paths:
               format: uuid
       responses:
         200:
-          description: 'No content, update successful'
+          description: 'Scenes in this project'
           schema:
             type: array
             items:

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -1873,7 +1873,7 @@ paths:
               type: string
               format: uuid
       responses:
-        201:
+        200:
           description: 'List of scenes added to project'
           schema:
             type: array
@@ -1903,8 +1903,12 @@ paths:
               type: string
               format: uuid
       responses:
-        204:
+        200:
           description: 'No content, update successful'
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Scene'
         403:
           description: 'Insufficient permissions or object does not exist'
           schema:


### PR DESCRIPTION
Overview
-----

This PR updates return codes and entities to be consistent with what the API actually
returns.

Testing
-----

- in the python client virtualenv: `RF_API_SPEC_PATH='https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/feature/js/update-scene-to-project-return-codes/spec/spec.yml' ipython`
- get a project id
- get some scene ids. Here are some if you don't feel like looking them up -- they're all public S2 scenes:

```
['000001fd-fe82-4e4e-8c43-4e08259c8318',
 '0000044b-bdda-4450-9ca7-5b0935296718',
 '0000048d-a377-4334-8d78-77205d0987c0',
 '00000566-d459-4be7-a350-9bc903c7e450',
 '00000756-9980-4738-af50-44db9777d88f']
```

- run the following:

```python
from rasterfoundry.api import API
client = API(refresh_token='<your refresh token>')
client.client.Imagery.post_projects_uuid_scenes(uuid='<your project id>', scenes=[<the scene ids>]).result()
```

- It should succeed, instead of freaking out about return codes

Closes #41 