### PR TITLE
Include ToolRunCreate model and POST params

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -18,9 +18,20 @@ then
     then
         usage
     else
-        # Execute yarn tests
-        docker-compose \
-            run --rm app \
-            yarn run test
+        # # Execute yarn tests
+        # docker-compose \
+        #     run --rm app \
+        #     yarn run test
+
+        # Make sure there's no difference between the two specs
+        echo 'Checking for differences between specs'
+        # specDiff=$(diff spec.yml spec/spec.yml)
+        # echo "${specDiff}"
+        # echo 'foo'
+        specDiffLines=$(diff ./spec.yml ./spec/spec.yml | wc -l)
+        if (("${specDiffLines}" > 0 )); then
+            echo 'Difference between spec.yml in repository root and spec/spec.yml'
+            exit 1
+        fi
     fi
 fi

--- a/spec.yml
+++ b/spec.yml
@@ -5416,6 +5416,8 @@ definitions:
             $ref: '#/definitions/ToolRun'
 
   ToolRunCreate:
+    type:
+      object
     properties:
       execution_parameters:
         type: object

--- a/spec.yml
+++ b/spec.yml
@@ -2844,6 +2844,12 @@ paths:
       summary: 'Create a tool run'
       tags:
         - Lab
+      parameters:
+        - name: analysisCreate
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ToolRunCreate'
       responses:
         201:
           description: 'Successfully created tool run'
@@ -5408,6 +5414,21 @@ definitions:
           type: array
           items:
             $ref: '#/definitions/ToolRun'
+
+  ToolRunCreate:
+    properties:
+      execution_parameters:
+        type: object
+        description: 'Parameters for running the tool'
+      name:
+        type : string
+      visibility:
+          type: string
+          description: 'Level of restriction on viewing'
+          enum:
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'      
 
   Error:
     type: object

--- a/spec.yml
+++ b/spec.yml
@@ -5405,16 +5405,6 @@ definitions:
             - 'ORGANIZATION'
             - 'PRIVATE'
 
-  ToolRunPaginated:
-    allOf:
-    - $ref: '#/definitions/PaginatedResponse'
-    - type: object
-      properties:
-        results:
-          type: array
-          items:
-            $ref: '#/definitions/ToolRun'
-
   ToolRunCreate:
     type:
       object
@@ -5431,6 +5421,16 @@ definitions:
           - 'PUBLIC'
           - 'ORGANIZATION'
           - 'PRIVATE'      
+
+  ToolRunPaginated:
+    allOf:
+    - $ref: '#/definitions/PaginatedResponse'
+    - type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/definitions/ToolRun'
 
   Error:
     type: object

--- a/spec.yml
+++ b/spec.yml
@@ -5423,12 +5423,12 @@ definitions:
       name:
         type : string
       visibility:
-          type: string
-          description: 'Level of restriction on viewing'
-          enum:
-            - 'PUBLIC'
-            - 'ORGANIZATION'
-            - 'PRIVATE'      
+        type: string
+        description: 'Level of restriction on viewing'
+        enum:
+          - 'PUBLIC'
+          - 'ORGANIZATION'
+          - 'PRIVATE'      
 
   Error:
     type: object

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -5406,6 +5406,8 @@ definitions:
             - 'PRIVATE'
 
   ToolRunCreate:
+    type:
+      object
     properties:
       execution_parameters:
         type: object

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -5404,6 +5404,7 @@ definitions:
             - 'PUBLIC'
             - 'ORGANIZATION'
             - 'PRIVATE'
+
   ToolRunCreate:
     properties:
       execution_parameters:

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -2844,6 +2844,12 @@ paths:
       summary: 'Create a tool run'
       tags:
         - Lab
+      parameters:
+        - name: analysisCreate
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/ToolRunCreate'
       responses:
         201:
           description: 'Successfully created tool run'
@@ -5398,6 +5404,20 @@ definitions:
             - 'PUBLIC'
             - 'ORGANIZATION'
             - 'PRIVATE'
+  ToolRunCreate:
+    properties:
+      execution_parameters:
+        type: object
+        description: 'Parameters for running the tool'
+      name:
+        type : string
+      visibility:
+          type: string
+          description: 'Level of restriction on viewing'
+          enum:
+            - 'PUBLIC'
+            - 'ORGANIZATION'
+            - 'PRIVATE'      
 
   ToolRunPaginated:
     allOf:

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -5413,12 +5413,12 @@ definitions:
       name:
         type : string
       visibility:
-          type: string
-          description: 'Level of restriction on viewing'
-          enum:
-            - 'PUBLIC'
-            - 'ORGANIZATION'
-            - 'PRIVATE'      
+        type: string
+        description: 'Level of restriction on viewing'
+        enum:
+          - 'PUBLIC'
+          - 'ORGANIZATION'
+          - 'PRIVATE'      
 
   ToolRunPaginated:
     allOf:


### PR DESCRIPTION
Overview
---

This PR adds parameters to tool runs to make interacting with them via the python client possible.

It also adds a spec consistency check to CI.

Testing
-----

- for the spec changes, RF client inconsistency with sensible spec actually nuked running this from the client project, so... compare with the case classes :(
- for the ci check: introduce a line into one spec but not the other, comment out the validation step of `scripts/test`, and run `./scripts/test` -- it should fail