### PR TITLE
Update datasource CRUD spec

### DIFF
--- a/spec.yml
+++ b/spec.yml
@@ -851,6 +851,70 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+
+  /datasources/{datasourceID}:
+    x-resource: Datasources
+    get:
+      summary: 'Get datasource by ID'
+      parameters:
+        - $ref: '#/parameters/datasourceID'
+      tags:
+        - Datasources
+      responses:
+        200:
+          description: SUCCESS
+          schema:
+            $ref: '#/definitions/Datasource'
+        403:
+          description: 'Insufficient permissions to get this datasource'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: 'Replace a datasource'
+      tags:
+        - Datasources
+      parameters:
+        - $ref: '#/parameters/datasourceID'
+        - name: datasource
+          in: body
+          required: true
+          schema:
+            allOf:
+              - $ref: '#/definitions/Datasource'
+              - $ref: '#/definitions/DatasourceBands'
+      responses:
+        204:
+          description: 'Update successful (no further processing needed)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: 'Delete a datasource'
+      tags:
+        - Datasources
+      parameters:
+        - $ref: '#/parameters/datasourceID'
+      responses:
+        204:
+          description: 'Deletion successful (no content)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
   /datasources/{datasourceID}/permissions/:
     x-resource: Datasources
     get:
@@ -4854,23 +4918,15 @@ definitions:
     type: object
     description: 'Datasource to be created'
     allOf:
+      - $ref: '#/definitions/DatasourceCreated'
+      - $ref: '#/definitions/DatasourceBands'
+
+  DatasourceBands:
+    type: object
+    description: 'Band definitions of a datasource'
+    allOf:
       - type: object
         properties:
-          visibility:
-            type: string
-            description: 'Level of restriction on viewing'
-            enum:
-              - 'PUBLIC'
-              - 'ORGANIZATION'
-              - 'PRIVATE'
-          name:
-            type: string
-            description: 'human label name for datasource'
-          extras:
-            type: object
-            description: 'additional related information for a datasource'
-          composites:
-            $ref: '#/definitions/Composite'
           bands:
             type: array
             items:

--- a/spec.yml
+++ b/spec.yml
@@ -904,7 +904,7 @@ paths:
       parameters:
         - $ref: '#/parameters/datasourceID'
       responses:
-        204:
+        200:
           description: 'Deletion successful (no content)'
         403:
           description: 'Insufficient permissions or object does not exist'

--- a/spec.yml
+++ b/spec.yml
@@ -837,8 +837,11 @@ paths:
       tags:
         - Datasources
       parameters:
-        - $ref: '#/parameters/owner'
-        - $ref: '#/parameters/name'
+        - name: datasource
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/DatasourceToCreate'
       responses:
         201:
           description: SUCCESS
@@ -4847,6 +4850,39 @@ definitions:
           blueBand:
             type: integer
 
+  DatasourceToCreate:
+    type: object
+    description: 'Datasource to be created'
+    allOf:
+      - type: object
+        properties:
+          visibility:
+            type: string
+            description: 'Level of restriction on viewing'
+            enum:
+              - 'PUBLIC'
+              - 'ORGANIZATION'
+              - 'PRIVATE'
+          name:
+            type: string
+            description: 'human label name for datasource'
+          extras:
+            type: object
+            description: 'additional related information for a datasource'
+          composites:
+            $ref: '#/definitions/Composite'
+          bands:
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                number:
+                  type: string
+                wavelength:
+                  type: number
+                  format: float
 
   DatasourceCreated:
     type: object
@@ -4910,6 +4946,7 @@ definitions:
           type: array
           items:
             $ref: '#/definitions/Datasource'
+
   License:
     type: object
     description: 'A record of license'

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -851,6 +851,70 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+
+  /datasources/{datasourceID}:
+    x-resource: Datasources
+    get:
+      summary: 'Get datasource by ID'
+      parameters:
+        - $ref: '#/parameters/datasourceID'
+      tags:
+        - Datasources
+      responses:
+        200:
+          description: SUCCESS
+          schema:
+            $ref: '#/definitions/Datasource'
+        403:
+          description: 'Insufficient permissions to get this datasource'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: 'Replace a datasource'
+      tags:
+        - Datasources
+      parameters:
+        - $ref: '#/parameters/datasourceID'
+        - name: datasource
+          in: body
+          required: true
+          schema:
+            allOf:
+              - $ref: '#/definitions/Datasource'
+              - $ref: '#/definitions/DatasourceBands'
+      responses:
+        204:
+          description: 'Update successful (no further processing needed)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: 'Delete a datasource'
+      tags:
+        - Datasources
+      parameters:
+        - $ref: '#/parameters/datasourceID'
+      responses:
+        204:
+          description: 'Deletion successful (no content)'
+        403:
+          description: 'Insufficient permissions or object does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
   /datasources/{datasourceID}/permissions/:
     x-resource: Datasources
     get:
@@ -4854,23 +4918,15 @@ definitions:
     type: object
     description: 'Datasource to be created'
     allOf:
+      - $ref: '#/definitions/DatasourceCreated'
+      - $ref: '#/definitions/DatasourceBands'
+
+  DatasourceBands:
+    type: object
+    description: 'Band definitions of a datasource'
+    allOf:
       - type: object
         properties:
-          visibility:
-            type: string
-            description: 'Level of restriction on viewing'
-            enum:
-              - 'PUBLIC'
-              - 'ORGANIZATION'
-              - 'PRIVATE'
-          name:
-            type: string
-            description: 'human label name for datasource'
-          extras:
-            type: object
-            description: 'additional related information for a datasource'
-          composites:
-            $ref: '#/definitions/Composite'
           bands:
             type: array
             items:

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -904,7 +904,7 @@ paths:
       parameters:
         - $ref: '#/parameters/datasourceID'
       responses:
-        204:
+        200:
           description: 'Deletion successful (no content)'
         403:
           description: 'Insufficient permissions or object does not exist'

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -837,8 +837,11 @@ paths:
       tags:
         - Datasources
       parameters:
-        - $ref: '#/parameters/owner'
-        - $ref: '#/parameters/name'
+        - name: datasource
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/DatasourceToCreate'
       responses:
         201:
           description: SUCCESS
@@ -4847,6 +4850,39 @@ definitions:
           blueBand:
             type: integer
 
+  DatasourceToCreate:
+    type: object
+    description: 'Datasource to be created'
+    allOf:
+      - type: object
+        properties:
+          visibility:
+            type: string
+            description: 'Level of restriction on viewing'
+            enum:
+              - 'PUBLIC'
+              - 'ORGANIZATION'
+              - 'PRIVATE'
+          name:
+            type: string
+            description: 'human label name for datasource'
+          extras:
+            type: object
+            description: 'additional related information for a datasource'
+          composites:
+            $ref: '#/definitions/Composite'
+          bands:
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  type: string
+                number:
+                  type: string
+                wavelength:
+                  type: number
+                  format: float
 
   DatasourceCreated:
     type: object
@@ -4910,6 +4946,7 @@ definitions:
           type: array
           items:
             $ref: '#/definitions/Datasource'
+
   License:
     type: object
     description: 'A record of license'


### PR DESCRIPTION
This PR updates spec for datasource CRUD endpoints to make https://github.com/raster-foundry/raster-foundry-python-client/pull/67 work.

This is a part of https://github.com/raster-foundry/raster-foundry-api-spec/issues/49