### PR TITLE
Include PR template and template unreleased changelog section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+### Checklist
+
+- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+
+## Testing Instructions
+
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case, and expected output
+
+Closes #XXX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## Unreleased(https://github.com/raster-foundry/raster-foundry/tree/develop)
+
+### Added
+
+### Changed
+
+- Switched to [keepachangelog](https://keepachangelog.com/en/1.0.0/) CHANGELOG format [\#xxx](https://github.com/raster-foundry/raster-foundry-api-spec/pull/xxx)
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
 
 ## [1.11.0](https://github.com/raster-foundry/raster-foundry-api-spec/tree/1.11.0) (2018-09-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- Switched to [keepachangelog](https://keepachangelog.com/en/1.0.0/) CHANGELOG format [\#xxx](https://github.com/raster-foundry/raster-foundry-api-spec/pull/xxx)
+- Switched to [keepachangelog](https://keepachangelog.com/en/1.0.0/) CHANGELOG format [\#52](https://github.com/raster-foundry/raster-foundry-api-spec/pull/52)
 
 ### Deprecated
 


### PR DESCRIPTION
## Overview

This PR includes a PR template and a template unreleased section in the changelog

### Checklist

- [x] Description of the PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible