### PR TITLE
Remove get from project/{}/order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Deprecated
 
 ### Removed
+- Remove /order GET from /projects/{} since it doesn't exist [\#56](https://github.com/raster-foundry/raster-foundry-api-spec/pull/56)
 
 ### Fixed
 

--- a/spec.yml
+++ b/spec.yml
@@ -2195,23 +2195,6 @@ paths:
             $ref: '#/definitions/Error'
   /projects/{projectID}/order:
     x-resource: Projects
-    get:
-      summary: 'Get a list of scene IDs belonging to a project'
-      tags:
-        - Imagery
-      parameters:
-        - $ref: '#/parameters/projectID'
-      responses:
-        200:
-          description: 'Order of scenes in project for mosaic purposes'
-        403:
-          description: 'Insufficient permissions or object does not exist'
-          schema:
-            $ref: '#/definitions/Error'
-        default:
-          description: 'Unexpected error'
-          schema:
-            $ref: '#/definitions/Error'
     put:
       summary: 'Set a z-index order for scenes within the specified project'
       tags:

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -2195,23 +2195,6 @@ paths:
             $ref: '#/definitions/Error'
   /projects/{projectID}/order:
     x-resource: Projects
-    get:
-      summary: 'Get a list of scene IDs belonging to a project'
-      tags:
-        - Imagery
-      parameters:
-        - $ref: '#/parameters/projectID'
-      responses:
-        200:
-          description: 'Order of scenes in project for mosaic purposes'
-        403:
-          description: 'Insufficient permissions or object does not exist'
-          schema:
-            $ref: '#/definitions/Error'
-        default:
-          description: 'Unexpected error'
-          schema:
-            $ref: '#/definitions/Error'
     put:
       summary: 'Set a z-index order for scenes within the specified project'
       tags:


### PR DESCRIPTION
## Overview
/order only accepts put requests

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Both spec files are updated

