### PR TITLE
Include tile server spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Created tile server spec [\#61](https://github.com/raster-foundry/raster-foundry-api-spec/pull/61)
+
 ### Changed
 - Publish spec YAML file to version prefixed directory [\#60](https://github.com/raster-foundry/raster-foundry-api-spec/pull/60)
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Azavea",
   "scripts": {
     "validate-api-spec": "swagger-cli validate spec/spec.yml",
-    "validate-prediction-api-spec": "swagger-cli validate spec/prediction-spec.yml"
+    "validate-prediction-api-spec": "swagger-cli validate spec/prediction-spec.yml",
     "validate-tile-spec": "swagger-cli validate spec/tile-spec.yml"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "validate-api-spec": "swagger-cli validate spec/spec.yml",
     "validate-prediction-api-spec": "swagger-cli validate spec/prediction-spec.yml"
+    "validate-tile-spec": "swagger-cli validate spec/tile-spec.yml"
   },
   "devDependencies": {
     "swagger-cli": "^2.1.0"

--- a/scripts/test
+++ b/scripts/test
@@ -26,5 +26,9 @@ then
         # Validate Raster Foundry Prediction API spec
         docker-compose run --rm app \
             yarn run validate-prediction-api-spec
+
+        # Validate Raster Foundry Tile spec
+        docker-compose run --rm app \
+                       yarn run validate-tile-spec
     fi
 fi

--- a/spec/tile-spec.yml
+++ b/spec/tile-spec.yml
@@ -261,766 +261,766 @@ definitions:
         type: integer
       1:
         required: false
-        type: int
+        type: integer
       2:
         required: false
-        type: int
+        type: integer
       3:
         required: false
-        type: int
+        type: integer
       4:
         required: false
-        type: int
+        type: integer
       5:
         required: false
-        type: int
+        type: integer
       6:
         required: false
-        type: int
+        type: integer
       7:
         required: false
-        type: int
+        type: integer
       8:
         required: false
-        type: int
+        type: integer
       9:
         required: false
-        type: int
+        type: integer
       10:
         required: false
-        type: int
+        type: integer
       11:
         required: false
-        type: int
+        type: integer
       12:
         required: false
-        type: int
+        type: integer
       13:
         required: false
-        type: int
+        type: integer
       14:
         required: false
-        type: int
+        type: integer
       15:
         required: false
-        type: int
+        type: integer
       16:
         required: false
-        type: int
+        type: integer
       17:
         required: false
-        type: int
+        type: integer
       18:
         required: false
-        type: int
+        type: integer
       19:
         required: false
-        type: int
+        type: integer
       20:
         required: false
-        type: int
+        type: integer
       21:
         required: false
-        type: int
+        type: integer
       22:
         required: false
-        type: int
+        type: integer
       23:
         required: false
-        type: int
+        type: integer
       24:
         required: false
-        type: int
+        type: integer
       25:
         required: false
-        type: int
+        type: integer
       26:
         required: false
-        type: int
+        type: integer
       27:
         required: false
-        type: int
+        type: integer
       28:
         required: false
-        type: int
+        type: integer
       29:
         required: false
-        type: int
+        type: integer
       30:
         required: false
-        type: int
+        type: integer
       31:
         required: false
-        type: int
+        type: integer
       32:
         required: false
-        type: int
+        type: integer
       33:
         required: false
-        type: int
+        type: integer
       34:
         required: false
-        type: int
+        type: integer
       35:
         required: false
-        type: int
+        type: integer
       36:
         required: false
-        type: int
+        type: integer
       37:
         required: false
-        type: int
+        type: integer
       38:
         required: false
-        type: int
+        type: integer
       39:
         required: false
-        type: int
+        type: integer
       40:
         required: false
-        type: int
+        type: integer
       41:
         required: false
-        type: int
+        type: integer
       42:
         required: false
-        type: int
+        type: integer
       43:
         required: false
-        type: int
+        type: integer
       44:
         required: false
-        type: int
+        type: integer
       45:
         required: false
-        type: int
+        type: integer
       46:
         required: false
-        type: int
+        type: integer
       47:
         required: false
-        type: int
+        type: integer
       48:
         required: false
-        type: int
+        type: integer
       49:
         required: false
-        type: int
+        type: integer
       50:
         required: false
-        type: int
+        type: integer
       51:
         required: false
-        type: int
+        type: integer
       52:
         required: false
-        type: int
+        type: integer
       53:
         required: false
-        type: int
+        type: integer
       54:
         required: false
-        type: int
+        type: integer
       55:
         required: false
-        type: int
+        type: integer
       56:
         required: false
-        type: int
+        type: integer
       57:
         required: false
-        type: int
+        type: integer
       58:
         required: false
-        type: int
+        type: integer
       59:
         required: false
-        type: int
+        type: integer
       60:
         required: false
-        type: int
+        type: integer
       61:
         required: false
-        type: int
+        type: integer
       62:
         required: false
-        type: int
+        type: integer
       63:
         required: false
-        type: int
+        type: integer
       64:
         required: false
-        type: int
+        type: integer
       65:
         required: false
-        type: int
+        type: integer
       66:
         required: false
-        type: int
+        type: integer
       67:
         required: false
-        type: int
+        type: integer
       68:
         required: false
-        type: int
+        type: integer
       69:
         required: false
-        type: int
+        type: integer
       70:
         required: false
-        type: int
+        type: integer
       71:
         required: false
-        type: int
+        type: integer
       72:
         required: false
-        type: int
+        type: integer
       73:
         required: false
-        type: int
+        type: integer
       74:
         required: false
-        type: int
+        type: integer
       75:
         required: false
-        type: int
+        type: integer
       76:
         required: false
-        type: int
+        type: integer
       77:
         required: false
-        type: int
+        type: integer
       78:
         required: false
-        type: int
+        type: integer
       79:
         required: false
-        type: int
+        type: integer
       80:
         required: false
-        type: int
+        type: integer
       81:
         required: false
-        type: int
+        type: integer
       82:
         required: false
-        type: int
+        type: integer
       83:
         required: false
-        type: int
+        type: integer
       84:
         required: false
-        type: int
+        type: integer
       85:
         required: false
-        type: int
+        type: integer
       86:
         required: false
-        type: int
+        type: integer
       87:
         required: false
-        type: int
+        type: integer
       88:
         required: false
-        type: int
+        type: integer
       89:
         required: false
-        type: int
+        type: integer
       90:
         required: false
-        type: int
+        type: integer
       91:
         required: false
-        type: int
+        type: integer
       92:
         required: false
-        type: int
+        type: integer
       93:
         required: false
-        type: int
+        type: integer
       94:
         required: false
-        type: int
+        type: integer
       95:
         required: false
-        type: int
+        type: integer
       96:
         required: false
-        type: int
+        type: integer
       97:
         required: false
-        type: int
+        type: integer
       98:
         required: false
-        type: int
+        type: integer
       99:
         required: false
-        type: int
+        type: integer
       100:
         required: false
-        type: int
+        type: integer
       101:
         required: false
-        type: int
+        type: integer
       102:
         required: false
-        type: int
+        type: integer
       103:
         required: false
-        type: int
+        type: integer
       104:
         required: false
-        type: int
+        type: integer
       105:
         required: false
-        type: int
+        type: integer
       106:
         required: false
-        type: int
+        type: integer
       107:
         required: false
-        type: int
+        type: integer
       108:
         required: false
-        type: int
+        type: integer
       109:
         required: false
-        type: int
+        type: integer
       110:
         required: false
-        type: int
+        type: integer
       111:
         required: false
-        type: int
+        type: integer
       112:
         required: false
-        type: int
+        type: integer
       113:
         required: false
-        type: int
+        type: integer
       114:
         required: false
-        type: int
+        type: integer
       115:
         required: false
-        type: int
+        type: integer
       116:
         required: false
-        type: int
+        type: integer
       117:
         required: false
-        type: int
+        type: integer
       118:
         required: false
-        type: int
+        type: integer
       119:
         required: false
-        type: int
+        type: integer
       120:
         required: false
-        type: int
+        type: integer
       121:
         required: false
-        type: int
+        type: integer
       122:
         required: false
-        type: int
+        type: integer
       123:
         required: false
-        type: int
+        type: integer
       124:
         required: false
-        type: int
+        type: integer
       125:
         required: false
-        type: int
+        type: integer
       126:
         required: false
-        type: int
+        type: integer
       127:
         required: false
-        type: int
+        type: integer
       128:
         required: false
-        type: int
+        type: integer
       129:
         required: false
-        type: int
+        type: integer
       130:
         required: false
-        type: int
+        type: integer
       131:
         required: false
-        type: int
+        type: integer
       132:
         required: false
-        type: int
+        type: integer
       133:
         required: false
-        type: int
+        type: integer
       134:
         required: false
-        type: int
+        type: integer
       135:
         required: false
-        type: int
+        type: integer
       136:
         required: false
-        type: int
+        type: integer
       137:
         required: false
-        type: int
+        type: integer
       138:
         required: false
-        type: int
+        type: integer
       139:
         required: false
-        type: int
+        type: integer
       140:
         required: false
-        type: int
+        type: integer
       141:
         required: false
-        type: int
+        type: integer
       142:
         required: false
-        type: int
+        type: integer
       143:
         required: false
-        type: int
+        type: integer
       144:
         required: false
-        type: int
+        type: integer
       145:
         required: false
-        type: int
+        type: integer
       146:
         required: false
-        type: int
+        type: integer
       147:
         required: false
-        type: int
+        type: integer
       148:
         required: false
-        type: int
+        type: integer
       149:
         required: false
-        type: int
+        type: integer
       150:
         required: false
-        type: int
+        type: integer
       151:
         required: false
-        type: int
+        type: integer
       152:
         required: false
-        type: int
+        type: integer
       153:
         required: false
-        type: int
+        type: integer
       154:
         required: false
-        type: int
+        type: integer
       155:
         required: false
-        type: int
+        type: integer
       156:
         required: false
-        type: int
+        type: integer
       157:
         required: false
-        type: int
+        type: integer
       158:
         required: false
-        type: int
+        type: integer
       159:
         required: false
-        type: int
+        type: integer
       160:
         required: false
-        type: int
+        type: integer
       161:
         required: false
-        type: int
+        type: integer
       162:
         required: false
-        type: int
+        type: integer
       163:
         required: false
-        type: int
+        type: integer
       164:
         required: false
-        type: int
+        type: integer
       165:
         required: false
-        type: int
+        type: integer
       166:
         required: false
-        type: int
+        type: integer
       167:
         required: false
-        type: int
+        type: integer
       168:
         required: false
-        type: int
+        type: integer
       169:
         required: false
-        type: int
+        type: integer
       170:
         required: false
-        type: int
+        type: integer
       171:
         required: false
-        type: int
+        type: integer
       172:
         required: false
-        type: int
+        type: integer
       173:
         required: false
-        type: int
+        type: integer
       174:
         required: false
-        type: int
+        type: integer
       175:
         required: false
-        type: int
+        type: integer
       176:
         required: false
-        type: int
+        type: integer
       177:
         required: false
-        type: int
+        type: integer
       178:
         required: false
-        type: int
+        type: integer
       179:
         required: false
-        type: int
+        type: integer
       180:
         required: false
-        type: int
+        type: integer
       181:
         required: false
-        type: int
+        type: integer
       182:
         required: false
-        type: int
+        type: integer
       183:
         required: false
-        type: int
+        type: integer
       184:
         required: false
-        type: int
+        type: integer
       185:
         required: false
-        type: int
+        type: integer
       186:
         required: false
-        type: int
+        type: integer
       187:
         required: false
-        type: int
+        type: integer
       188:
         required: false
-        type: int
+        type: integer
       189:
         required: false
-        type: int
+        type: integer
       190:
         required: false
-        type: int
+        type: integer
       191:
         required: false
-        type: int
+        type: integer
       192:
         required: false
-        type: int
+        type: integer
       193:
         required: false
-        type: int
+        type: integer
       194:
         required: false
-        type: int
+        type: integer
       195:
         required: false
-        type: int
+        type: integer
       196:
         required: false
-        type: int
+        type: integer
       197:
         required: false
-        type: int
+        type: integer
       198:
         required: false
-        type: int
+        type: integer
       199:
         required: false
-        type: int
+        type: integer
       200:
         required: false
-        type: int
+        type: integer
       201:
         required: false
-        type: int
+        type: integer
       202:
         required: false
-        type: int
+        type: integer
       203:
         required: false
-        type: int
+        type: integer
       204:
         required: false
-        type: int
+        type: integer
       205:
         required: false
-        type: int
+        type: integer
       206:
         required: false
-        type: int
+        type: integer
       207:
         required: false
-        type: int
+        type: integer
       208:
         required: false
-        type: int
+        type: integer
       209:
         required: false
-        type: int
+        type: integer
       210:
         required: false
-        type: int
+        type: integer
       211:
         required: false
-        type: int
+        type: integer
       212:
         required: false
-        type: int
+        type: integer
       213:
         required: false
-        type: int
+        type: integer
       214:
         required: false
-        type: int
+        type: integer
       215:
         required: false
-        type: int
+        type: integer
       216:
         required: false
-        type: int
+        type: integer
       217:
         required: false
-        type: int
+        type: integer
       218:
         required: false
-        type: int
+        type: integer
       219:
         required: false
-        type: int
+        type: integer
       220:
         required: false
-        type: int
+        type: integer
       221:
         required: false
-        type: int
+        type: integer
       222:
         required: false
-        type: int
+        type: integer
       223:
         required: false
-        type: int
+        type: integer
       224:
         required: false
-        type: int
+        type: integer
       225:
         required: false
-        type: int
+        type: integer
       226:
         required: false
-        type: int
+        type: integer
       227:
         required: false
-        type: int
+        type: integer
       228:
         required: false
-        type: int
+        type: integer
       229:
         required: false
-        type: int
+        type: integer
       230:
         required: false
-        type: int
+        type: integer
       231:
         required: false
-        type: int
+        type: integer
       232:
         required: false
-        type: int
+        type: integer
       233:
         required: false
-        type: int
+        type: integer
       234:
         required: false
-        type: int
+        type: integer
       235:
         required: false
-        type: int
+        type: integer
       236:
         required: false
-        type: int
+        type: integer
       237:
         required: false
-        type: int
+        type: integer
       238:
         required: false
-        type: int
+        type: integer
       239:
         required: false
-        type: int
+        type: integer
       240:
         required: false
-        type: int
+        type: integer
       241:
         required: false
-        type: int
+        type: integer
       242:
         required: false
-        type: int
+        type: integer
       243:
         required: false
-        type: int
+        type: integer
       244:
         required: false
-        type: int
+        type: integer
       245:
         required: false
-        type: int
+        type: integer
       246:
         required: false
-        type: int
+        type: integer
       247:
         required: false
-        type: int
+        type: integer
       248:
         required: false
-        type: int
+        type: integer
       249:
         required: false
-        type: int
+        type: integer
       250:
         required: false
-        type: int
+        type: integer
       251:
         required: false
-        type: int
+        type: integer
       252:
         required: false
-        type: int
+        type: integer
       253:
         required: false
-        type: int
+        type: integer
       254:
         required: false
-        type: int
+        type: integer
       255:
         required: false
-        type: int
+        type: integer

--- a/spec/tile-spec.yml
+++ b/spec/tile-spec.yml
@@ -73,7 +73,7 @@ paths:
                   type: string
 
   /tools/{analysisId}/{z}/{x}/{y}/:
-    x-resource: Anslysis
+    x-resource: Analysis
     get:
       produces:
         - image/png

--- a/spec/tile-spec.yml
+++ b/spec/tile-spec.yml
@@ -91,6 +91,7 @@ paths:
           in: path
           type: string
           format: uuid
+          required: true
         - name: node
           description: 'ID of the subnode of this analysis to visualize'
           in: query
@@ -152,9 +153,11 @@ paths:
         403:
           description: 'Project does not exist or user is not authorized to view analysis'
     post:
-      summary: 'Obtain the histogram for this a subset of the scenes in this project\'s mosaic'
+      summary: 'Obtain the histogram for this a subset of the scenes in the mosaic for this project'
       tags:
         - Mosaic
+      consumes:
+        - text/plain
       parameters:
         - $ref: '#/parameters/token'
         - $ref: '#/parameters/mapToken'
@@ -162,11 +165,21 @@ paths:
         - $ref: '#/parameters/greenBandOverride'
         - $ref: '#/parameters/blueBandOverride'
         - $ref: '#/parameters/projectId'
-        - type: array
-          items:
-            type: string
-            format: uuid
-          in: body
+        - in: body
+          name: scenesSubset
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
+      responses:
+        200:
+          description: OK
+        401:
+          description: 'Authentication failed -- no authentication methods succeeded'
+        403:
+          description: 'Project does not exist or user is not authorized to view analysis'
 
 parameters:
   projectId:
@@ -175,36 +188,43 @@ parameters:
     description: 'ID of the project to visualize'
     type: string
     format: uuid
+    required: true
 
   zoom:
     name: z
     in: path
     description: 'Zoom level for tile visualization'
     type: integer
+    required: true
 
   x:
     name: x
     in: path
     description: 'Column for tile visualization'
     type: integer
+    required: true
 
   y:
     name: y
     in: path
     description: 'Row for tile visualization'
     type: integer
+    required: true
 
   token:
     name: token
     in: query
     description: 'Token to use for authorization'
     required: false
+    type: string
 
   mapToken:
     name: mapToken
     in: query
     description: 'Map token to use for authorization'
     required: false
+    type: string
+    format: uuid
 
   redBandOverride:
     name: redBand

--- a/spec/tile-spec.yml
+++ b/spec/tile-spec.yml
@@ -81,7 +81,7 @@ paths:
       tags:
         - Analysis
       parameters:
-        - $ref: '#/parameters/zoom'
+        - $ref: '#/parameters/z'
         - $ref: '#/parameters/x'
         - $ref: '#/parameters/y'
         - $ref: '#/parameters/token'
@@ -115,7 +115,7 @@ paths:
       tags:
         - Mosaic
       parameters:
-        - $ref: '#/parameters/zoom'
+        - $ref: '#/parameters/z'
         - $ref: '#/parameters/x'
         - $ref: '#/parameters/y'
         - $ref: '#/parameters/token'
@@ -198,7 +198,7 @@ parameters:
     format: uuid
     required: true
 
-  zoom:
+  z:
     name: z
     in: path
     description: 'Zoom level for tile visualization'

--- a/spec/tile-spec.yml
+++ b/spec/tile-spec.yml
@@ -27,7 +27,7 @@ x-top-matter:
     level: 2
     content: |
       You can authenticate with the backsplash tile server in one of three ways:
-        - mapToken query parameters: these are in the form of UUIDs included as query parameters. You can get one of these from a project in the Raster Foundry application.
+        - mapToken query parameters: these are in the form of UUIDs included as query parameters. You can get one of these from a project or analysis in the Raster Foundry application.
         - token  query parameter: This is a <a href="https://jwt.io/introduction/" target="_blank">JSON Web Token (JWT)</a> that you include in a query parameter called 'token'. It <i>does not</i> include the 'Bearer ' component of the token.
         - authorization headers: This is a <a href="https://jwt.io/introduction/" target="_blank">JSON Web Token (JWT)</a>. You can create one with a refresh token created in the Raster Foundry application.
 

--- a/spec/tile-spec.yml
+++ b/spec/tile-spec.yml
@@ -257,770 +257,514 @@ definitions:
     type: object
     properties:
       0: 
-        required: false
         type: integer
       1:
-        required: false
         type: integer
       2:
-        required: false
         type: integer
       3:
-        required: false
         type: integer
       4:
-        required: false
         type: integer
       5:
-        required: false
         type: integer
       6:
-        required: false
         type: integer
       7:
-        required: false
         type: integer
       8:
-        required: false
         type: integer
       9:
-        required: false
         type: integer
       10:
-        required: false
         type: integer
       11:
-        required: false
         type: integer
       12:
-        required: false
         type: integer
       13:
-        required: false
         type: integer
       14:
-        required: false
         type: integer
       15:
-        required: false
         type: integer
       16:
-        required: false
         type: integer
       17:
-        required: false
         type: integer
       18:
-        required: false
         type: integer
       19:
-        required: false
         type: integer
       20:
-        required: false
         type: integer
       21:
-        required: false
         type: integer
       22:
-        required: false
         type: integer
       23:
-        required: false
         type: integer
       24:
-        required: false
         type: integer
       25:
-        required: false
         type: integer
       26:
-        required: false
         type: integer
       27:
-        required: false
         type: integer
       28:
-        required: false
         type: integer
       29:
-        required: false
         type: integer
       30:
-        required: false
         type: integer
       31:
-        required: false
         type: integer
       32:
-        required: false
         type: integer
       33:
-        required: false
         type: integer
       34:
-        required: false
         type: integer
       35:
-        required: false
         type: integer
       36:
-        required: false
         type: integer
       37:
-        required: false
         type: integer
       38:
-        required: false
         type: integer
       39:
-        required: false
         type: integer
       40:
-        required: false
         type: integer
       41:
-        required: false
         type: integer
       42:
-        required: false
         type: integer
       43:
-        required: false
         type: integer
       44:
-        required: false
         type: integer
       45:
-        required: false
         type: integer
       46:
-        required: false
         type: integer
       47:
-        required: false
         type: integer
       48:
-        required: false
         type: integer
       49:
-        required: false
         type: integer
       50:
-        required: false
         type: integer
       51:
-        required: false
         type: integer
       52:
-        required: false
         type: integer
       53:
-        required: false
         type: integer
       54:
-        required: false
         type: integer
       55:
-        required: false
         type: integer
       56:
-        required: false
         type: integer
       57:
-        required: false
         type: integer
       58:
-        required: false
         type: integer
       59:
-        required: false
         type: integer
       60:
-        required: false
         type: integer
       61:
-        required: false
         type: integer
       62:
-        required: false
         type: integer
       63:
-        required: false
         type: integer
       64:
-        required: false
         type: integer
       65:
-        required: false
         type: integer
       66:
-        required: false
         type: integer
       67:
-        required: false
         type: integer
       68:
-        required: false
         type: integer
       69:
-        required: false
         type: integer
       70:
-        required: false
         type: integer
       71:
-        required: false
         type: integer
       72:
-        required: false
         type: integer
       73:
-        required: false
         type: integer
       74:
-        required: false
         type: integer
       75:
-        required: false
         type: integer
       76:
-        required: false
         type: integer
       77:
-        required: false
         type: integer
       78:
-        required: false
         type: integer
       79:
-        required: false
         type: integer
       80:
-        required: false
         type: integer
       81:
-        required: false
         type: integer
       82:
-        required: false
         type: integer
       83:
-        required: false
         type: integer
       84:
-        required: false
         type: integer
       85:
-        required: false
         type: integer
       86:
-        required: false
         type: integer
       87:
-        required: false
         type: integer
       88:
-        required: false
         type: integer
       89:
-        required: false
         type: integer
       90:
-        required: false
         type: integer
       91:
-        required: false
         type: integer
       92:
-        required: false
         type: integer
       93:
-        required: false
         type: integer
       94:
-        required: false
         type: integer
       95:
-        required: false
         type: integer
       96:
-        required: false
         type: integer
       97:
-        required: false
         type: integer
       98:
-        required: false
         type: integer
       99:
-        required: false
         type: integer
       100:
-        required: false
         type: integer
       101:
-        required: false
         type: integer
       102:
-        required: false
         type: integer
       103:
-        required: false
         type: integer
       104:
-        required: false
         type: integer
       105:
-        required: false
         type: integer
       106:
-        required: false
         type: integer
       107:
-        required: false
         type: integer
       108:
-        required: false
         type: integer
       109:
-        required: false
         type: integer
       110:
-        required: false
         type: integer
       111:
-        required: false
         type: integer
       112:
-        required: false
         type: integer
       113:
-        required: false
         type: integer
       114:
-        required: false
         type: integer
       115:
-        required: false
         type: integer
       116:
-        required: false
         type: integer
       117:
-        required: false
         type: integer
       118:
-        required: false
         type: integer
       119:
-        required: false
         type: integer
       120:
-        required: false
         type: integer
       121:
-        required: false
         type: integer
       122:
-        required: false
         type: integer
       123:
-        required: false
         type: integer
       124:
-        required: false
         type: integer
       125:
-        required: false
         type: integer
       126:
-        required: false
         type: integer
       127:
-        required: false
         type: integer
       128:
-        required: false
         type: integer
       129:
-        required: false
         type: integer
       130:
-        required: false
         type: integer
       131:
-        required: false
         type: integer
       132:
-        required: false
         type: integer
       133:
-        required: false
         type: integer
       134:
-        required: false
         type: integer
       135:
-        required: false
         type: integer
       136:
-        required: false
         type: integer
       137:
-        required: false
         type: integer
       138:
-        required: false
         type: integer
       139:
-        required: false
         type: integer
       140:
-        required: false
         type: integer
       141:
-        required: false
         type: integer
       142:
-        required: false
         type: integer
       143:
-        required: false
         type: integer
       144:
-        required: false
         type: integer
       145:
-        required: false
         type: integer
       146:
-        required: false
         type: integer
       147:
-        required: false
         type: integer
       148:
-        required: false
         type: integer
       149:
-        required: false
         type: integer
       150:
-        required: false
         type: integer
       151:
-        required: false
         type: integer
       152:
-        required: false
         type: integer
       153:
-        required: false
         type: integer
       154:
-        required: false
         type: integer
       155:
-        required: false
         type: integer
       156:
-        required: false
         type: integer
       157:
-        required: false
         type: integer
       158:
-        required: false
         type: integer
       159:
-        required: false
         type: integer
       160:
-        required: false
         type: integer
       161:
-        required: false
         type: integer
       162:
-        required: false
         type: integer
       163:
-        required: false
         type: integer
       164:
-        required: false
         type: integer
       165:
-        required: false
         type: integer
       166:
-        required: false
         type: integer
       167:
-        required: false
         type: integer
       168:
-        required: false
         type: integer
       169:
-        required: false
         type: integer
       170:
-        required: false
         type: integer
       171:
-        required: false
         type: integer
       172:
-        required: false
         type: integer
       173:
-        required: false
         type: integer
       174:
-        required: false
         type: integer
       175:
-        required: false
         type: integer
       176:
-        required: false
         type: integer
       177:
-        required: false
         type: integer
       178:
-        required: false
         type: integer
       179:
-        required: false
         type: integer
       180:
-        required: false
         type: integer
       181:
-        required: false
         type: integer
       182:
-        required: false
         type: integer
       183:
-        required: false
         type: integer
       184:
-        required: false
         type: integer
       185:
-        required: false
         type: integer
       186:
-        required: false
         type: integer
       187:
-        required: false
         type: integer
       188:
-        required: false
         type: integer
       189:
-        required: false
         type: integer
       190:
-        required: false
         type: integer
       191:
-        required: false
         type: integer
       192:
-        required: false
         type: integer
       193:
-        required: false
         type: integer
       194:
-        required: false
         type: integer
       195:
-        required: false
         type: integer
       196:
-        required: false
         type: integer
       197:
-        required: false
         type: integer
       198:
-        required: false
         type: integer
       199:
-        required: false
         type: integer
       200:
-        required: false
         type: integer
       201:
-        required: false
         type: integer
       202:
-        required: false
         type: integer
       203:
-        required: false
         type: integer
       204:
-        required: false
         type: integer
       205:
-        required: false
         type: integer
       206:
-        required: false
         type: integer
       207:
-        required: false
         type: integer
       208:
-        required: false
         type: integer
       209:
-        required: false
         type: integer
       210:
-        required: false
         type: integer
       211:
-        required: false
         type: integer
       212:
-        required: false
         type: integer
       213:
-        required: false
         type: integer
       214:
-        required: false
         type: integer
       215:
-        required: false
         type: integer
       216:
-        required: false
         type: integer
       217:
-        required: false
         type: integer
       218:
-        required: false
         type: integer
       219:
-        required: false
         type: integer
       220:
-        required: false
         type: integer
       221:
-        required: false
         type: integer
       222:
-        required: false
         type: integer
       223:
-        required: false
         type: integer
       224:
-        required: false
         type: integer
       225:
-        required: false
         type: integer
       226:
-        required: false
         type: integer
       227:
-        required: false
         type: integer
       228:
-        required: false
         type: integer
       229:
-        required: false
         type: integer
       230:
-        required: false
         type: integer
       231:
-        required: false
         type: integer
       232:
-        required: false
         type: integer
       233:
-        required: false
         type: integer
       234:
-        required: false
         type: integer
       235:
-        required: false
         type: integer
       236:
-        required: false
         type: integer
       237:
-        required: false
         type: integer
       238:
-        required: false
         type: integer
       239:
-        required: false
         type: integer
       240:
-        required: false
         type: integer
       241:
-        required: false
         type: integer
       242:
-        required: false
         type: integer
       243:
-        required: false
         type: integer
       244:
-        required: false
         type: integer
       245:
-        required: false
         type: integer
       246:
-        required: false
         type: integer
       247:
-        required: false
         type: integer
       248:
-        required: false
         type: integer
       249:
-        required: false
         type: integer
       250:
-        required: false
         type: integer
       251:
-        required: false
         type: integer
       252:
-        required: false
         type: integer
       253:
-        required: false
         type: integer
       254:
-        required: false
         type: integer
       255:
-        required: false
         type: integer

--- a/spec/tile-spec.yml
+++ b/spec/tile-spec.yml
@@ -134,7 +134,7 @@ paths:
   /{projectId}/histogram/:
     x-resource: Mosaic
     get:
-      summary: 'Obtain the histogram of this project\'s mosaic'
+      summary: 'Obtain the project mosaic histogram'
       tags:
         - Mosaic
       parameters:

--- a/spec/tile-spec.yml
+++ b/spec/tile-spec.yml
@@ -148,6 +148,10 @@ paths:
       responses:
         200:
           description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Histogram'
         401:
           description: 'Authentication failed -- no authentication methods succeeded'
         403:
@@ -176,6 +180,10 @@ paths:
       responses:
         200:
           description: OK
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Histogram'
         401:
           description: 'Authentication failed -- no authentication methods succeeded'
         403:
@@ -243,3 +251,776 @@ parameters:
     in: query
     description: 'Specific band to use for blue if overriding project settings'
     type: integer
+
+definitions:
+  Histogram:
+    type: object
+    properties:
+      0: 
+        required: false
+        type: integer
+      1:
+        required: false
+        type: int
+      2:
+        required: false
+        type: int
+      3:
+        required: false
+        type: int
+      4:
+        required: false
+        type: int
+      5:
+        required: false
+        type: int
+      6:
+        required: false
+        type: int
+      7:
+        required: false
+        type: int
+      8:
+        required: false
+        type: int
+      9:
+        required: false
+        type: int
+      10:
+        required: false
+        type: int
+      11:
+        required: false
+        type: int
+      12:
+        required: false
+        type: int
+      13:
+        required: false
+        type: int
+      14:
+        required: false
+        type: int
+      15:
+        required: false
+        type: int
+      16:
+        required: false
+        type: int
+      17:
+        required: false
+        type: int
+      18:
+        required: false
+        type: int
+      19:
+        required: false
+        type: int
+      20:
+        required: false
+        type: int
+      21:
+        required: false
+        type: int
+      22:
+        required: false
+        type: int
+      23:
+        required: false
+        type: int
+      24:
+        required: false
+        type: int
+      25:
+        required: false
+        type: int
+      26:
+        required: false
+        type: int
+      27:
+        required: false
+        type: int
+      28:
+        required: false
+        type: int
+      29:
+        required: false
+        type: int
+      30:
+        required: false
+        type: int
+      31:
+        required: false
+        type: int
+      32:
+        required: false
+        type: int
+      33:
+        required: false
+        type: int
+      34:
+        required: false
+        type: int
+      35:
+        required: false
+        type: int
+      36:
+        required: false
+        type: int
+      37:
+        required: false
+        type: int
+      38:
+        required: false
+        type: int
+      39:
+        required: false
+        type: int
+      40:
+        required: false
+        type: int
+      41:
+        required: false
+        type: int
+      42:
+        required: false
+        type: int
+      43:
+        required: false
+        type: int
+      44:
+        required: false
+        type: int
+      45:
+        required: false
+        type: int
+      46:
+        required: false
+        type: int
+      47:
+        required: false
+        type: int
+      48:
+        required: false
+        type: int
+      49:
+        required: false
+        type: int
+      50:
+        required: false
+        type: int
+      51:
+        required: false
+        type: int
+      52:
+        required: false
+        type: int
+      53:
+        required: false
+        type: int
+      54:
+        required: false
+        type: int
+      55:
+        required: false
+        type: int
+      56:
+        required: false
+        type: int
+      57:
+        required: false
+        type: int
+      58:
+        required: false
+        type: int
+      59:
+        required: false
+        type: int
+      60:
+        required: false
+        type: int
+      61:
+        required: false
+        type: int
+      62:
+        required: false
+        type: int
+      63:
+        required: false
+        type: int
+      64:
+        required: false
+        type: int
+      65:
+        required: false
+        type: int
+      66:
+        required: false
+        type: int
+      67:
+        required: false
+        type: int
+      68:
+        required: false
+        type: int
+      69:
+        required: false
+        type: int
+      70:
+        required: false
+        type: int
+      71:
+        required: false
+        type: int
+      72:
+        required: false
+        type: int
+      73:
+        required: false
+        type: int
+      74:
+        required: false
+        type: int
+      75:
+        required: false
+        type: int
+      76:
+        required: false
+        type: int
+      77:
+        required: false
+        type: int
+      78:
+        required: false
+        type: int
+      79:
+        required: false
+        type: int
+      80:
+        required: false
+        type: int
+      81:
+        required: false
+        type: int
+      82:
+        required: false
+        type: int
+      83:
+        required: false
+        type: int
+      84:
+        required: false
+        type: int
+      85:
+        required: false
+        type: int
+      86:
+        required: false
+        type: int
+      87:
+        required: false
+        type: int
+      88:
+        required: false
+        type: int
+      89:
+        required: false
+        type: int
+      90:
+        required: false
+        type: int
+      91:
+        required: false
+        type: int
+      92:
+        required: false
+        type: int
+      93:
+        required: false
+        type: int
+      94:
+        required: false
+        type: int
+      95:
+        required: false
+        type: int
+      96:
+        required: false
+        type: int
+      97:
+        required: false
+        type: int
+      98:
+        required: false
+        type: int
+      99:
+        required: false
+        type: int
+      100:
+        required: false
+        type: int
+      101:
+        required: false
+        type: int
+      102:
+        required: false
+        type: int
+      103:
+        required: false
+        type: int
+      104:
+        required: false
+        type: int
+      105:
+        required: false
+        type: int
+      106:
+        required: false
+        type: int
+      107:
+        required: false
+        type: int
+      108:
+        required: false
+        type: int
+      109:
+        required: false
+        type: int
+      110:
+        required: false
+        type: int
+      111:
+        required: false
+        type: int
+      112:
+        required: false
+        type: int
+      113:
+        required: false
+        type: int
+      114:
+        required: false
+        type: int
+      115:
+        required: false
+        type: int
+      116:
+        required: false
+        type: int
+      117:
+        required: false
+        type: int
+      118:
+        required: false
+        type: int
+      119:
+        required: false
+        type: int
+      120:
+        required: false
+        type: int
+      121:
+        required: false
+        type: int
+      122:
+        required: false
+        type: int
+      123:
+        required: false
+        type: int
+      124:
+        required: false
+        type: int
+      125:
+        required: false
+        type: int
+      126:
+        required: false
+        type: int
+      127:
+        required: false
+        type: int
+      128:
+        required: false
+        type: int
+      129:
+        required: false
+        type: int
+      130:
+        required: false
+        type: int
+      131:
+        required: false
+        type: int
+      132:
+        required: false
+        type: int
+      133:
+        required: false
+        type: int
+      134:
+        required: false
+        type: int
+      135:
+        required: false
+        type: int
+      136:
+        required: false
+        type: int
+      137:
+        required: false
+        type: int
+      138:
+        required: false
+        type: int
+      139:
+        required: false
+        type: int
+      140:
+        required: false
+        type: int
+      141:
+        required: false
+        type: int
+      142:
+        required: false
+        type: int
+      143:
+        required: false
+        type: int
+      144:
+        required: false
+        type: int
+      145:
+        required: false
+        type: int
+      146:
+        required: false
+        type: int
+      147:
+        required: false
+        type: int
+      148:
+        required: false
+        type: int
+      149:
+        required: false
+        type: int
+      150:
+        required: false
+        type: int
+      151:
+        required: false
+        type: int
+      152:
+        required: false
+        type: int
+      153:
+        required: false
+        type: int
+      154:
+        required: false
+        type: int
+      155:
+        required: false
+        type: int
+      156:
+        required: false
+        type: int
+      157:
+        required: false
+        type: int
+      158:
+        required: false
+        type: int
+      159:
+        required: false
+        type: int
+      160:
+        required: false
+        type: int
+      161:
+        required: false
+        type: int
+      162:
+        required: false
+        type: int
+      163:
+        required: false
+        type: int
+      164:
+        required: false
+        type: int
+      165:
+        required: false
+        type: int
+      166:
+        required: false
+        type: int
+      167:
+        required: false
+        type: int
+      168:
+        required: false
+        type: int
+      169:
+        required: false
+        type: int
+      170:
+        required: false
+        type: int
+      171:
+        required: false
+        type: int
+      172:
+        required: false
+        type: int
+      173:
+        required: false
+        type: int
+      174:
+        required: false
+        type: int
+      175:
+        required: false
+        type: int
+      176:
+        required: false
+        type: int
+      177:
+        required: false
+        type: int
+      178:
+        required: false
+        type: int
+      179:
+        required: false
+        type: int
+      180:
+        required: false
+        type: int
+      181:
+        required: false
+        type: int
+      182:
+        required: false
+        type: int
+      183:
+        required: false
+        type: int
+      184:
+        required: false
+        type: int
+      185:
+        required: false
+        type: int
+      186:
+        required: false
+        type: int
+      187:
+        required: false
+        type: int
+      188:
+        required: false
+        type: int
+      189:
+        required: false
+        type: int
+      190:
+        required: false
+        type: int
+      191:
+        required: false
+        type: int
+      192:
+        required: false
+        type: int
+      193:
+        required: false
+        type: int
+      194:
+        required: false
+        type: int
+      195:
+        required: false
+        type: int
+      196:
+        required: false
+        type: int
+      197:
+        required: false
+        type: int
+      198:
+        required: false
+        type: int
+      199:
+        required: false
+        type: int
+      200:
+        required: false
+        type: int
+      201:
+        required: false
+        type: int
+      202:
+        required: false
+        type: int
+      203:
+        required: false
+        type: int
+      204:
+        required: false
+        type: int
+      205:
+        required: false
+        type: int
+      206:
+        required: false
+        type: int
+      207:
+        required: false
+        type: int
+      208:
+        required: false
+        type: int
+      209:
+        required: false
+        type: int
+      210:
+        required: false
+        type: int
+      211:
+        required: false
+        type: int
+      212:
+        required: false
+        type: int
+      213:
+        required: false
+        type: int
+      214:
+        required: false
+        type: int
+      215:
+        required: false
+        type: int
+      216:
+        required: false
+        type: int
+      217:
+        required: false
+        type: int
+      218:
+        required: false
+        type: int
+      219:
+        required: false
+        type: int
+      220:
+        required: false
+        type: int
+      221:
+        required: false
+        type: int
+      222:
+        required: false
+        type: int
+      223:
+        required: false
+        type: int
+      224:
+        required: false
+        type: int
+      225:
+        required: false
+        type: int
+      226:
+        required: false
+        type: int
+      227:
+        required: false
+        type: int
+      228:
+        required: false
+        type: int
+      229:
+        required: false
+        type: int
+      230:
+        required: false
+        type: int
+      231:
+        required: false
+        type: int
+      232:
+        required: false
+        type: int
+      233:
+        required: false
+        type: int
+      234:
+        required: false
+        type: int
+      235:
+        required: false
+        type: int
+      236:
+        required: false
+        type: int
+      237:
+        required: false
+        type: int
+      238:
+        required: false
+        type: int
+      239:
+        required: false
+        type: int
+      240:
+        required: false
+        type: int
+      241:
+        required: false
+        type: int
+      242:
+        required: false
+        type: int
+      243:
+        required: false
+        type: int
+      244:
+        required: false
+        type: int
+      245:
+        required: false
+        type: int
+      246:
+        required: false
+        type: int
+      247:
+        required: false
+        type: int
+      248:
+        required: false
+        type: int
+      249:
+        required: false
+        type: int
+      250:
+        required: false
+        type: int
+      251:
+        required: false
+        type: int
+      252:
+        required: false
+        type: int
+      253:
+        required: false
+        type: int
+      254:
+        required: false
+        type: int
+      255:
+        required: false
+        type: int

--- a/spec/tile-spec.yml
+++ b/spec/tile-spec.yml
@@ -1,0 +1,225 @@
+swagger: '2.0'
+info:
+  title: Raster Foundry
+  description: An application to find, view, and analyze geospatial data at any scale
+  version: "0.1.0"
+
+host: backsplash.rasterfoundry.com
+
+schemes:
+  - http
+  - https
+
+basePath: /
+
+produces:
+  - application/json
+  - img/png
+consumes:
+  - application/json
+
+x-top-matter:
+  - title: Introduction
+    level: 1
+    content: |
+      The backsplash server serves tiles and statistical information about tile layers in the Raster Foundry application.
+  - title: Authentication
+    level: 2
+    content: |
+      You can authenticate with the backsplash tile server in one of three ways:
+        - mapToken query parameters: these are in the form of UUIDs included as query parameters. You can get one of these from a project in the Raster Foundry application.
+        - token  query parameter: This is a <a href="https://jwt.io/introduction/" target="_blank">JSON Web Token (JWT)</a> that you include in a query parameter called 'token'. It <i>does not</i> include the 'Bearer ' component of the token.
+        - authorization headers: This is a <a href="https://jwt.io/introduction/" target="_blank">JSON Web Token (JWT)</a>. You can create one with a refresh token created in the Raster Foundry application.
+
+x-resources:
+  - name: Mosaic
+    description: |
+      Single- or multi-band visualization of a project layer.
+  - name: Analysis
+    description: |
+      Visualization of the results of map algebraic computations
+  - name: Healthcheck
+    description: |
+      Assurance that the tile server is still alive
+
+tags:
+  - name: Mosaic
+    description: 'Interact with mosaics'
+  - name: Analysis
+    description: |
+      Visualization of the results of map algebraic computations
+  - name: Healthcheck
+    description: |
+      Assurance that the tile server is still alive
+
+paths:
+  /healthcheck/:
+    x-resource: Healthcheck
+    get:
+      summary: 'Confirm the tile server is available'
+      tags:
+        - Healthcheck
+      responses:
+        200:
+          description: 'OK'
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+              reason:
+                type: array
+                items:
+                  type: string
+
+  /tools/{analysisId}/{z}/{x}/{y}/:
+    x-resource: Anslysis
+    get:
+      produces:
+        - image/png
+      summary: Visualize an analysis (or node of an analysis) as a tile
+      tags:
+        - Analysis
+      parameters:
+        - $ref: '#/parameters/zoom'
+        - $ref: '#/parameters/x'
+        - $ref: '#/parameters/y'
+        - $ref: '#/parameters/token'
+        - $ref: '#/parameters/mapToken'
+        - name: analysisId
+          description: 'ID of the analysis to visualize'
+          in: path
+          type: string
+          format: uuid
+        - name: node
+          description: 'ID of the subnode of this analysis to visualize'
+          in: query
+          type: string
+          format: uuid
+          required: false
+      responses:
+        200:
+          description: OK
+        401:
+          description: 'Authentication failed -- no authentication methods succeeded'
+        403:
+          description: 'Analysis does not exist or user is not authorized to view analysis'
+
+  /{projectId}/{z}/{x}/{y}/:
+    x-resource: Mosaic
+    get:
+      produces:
+        - image/png
+      summary: Visualize a mosaic of a project
+      tags:
+        - Mosaic
+      parameters:
+        - $ref: '#/parameters/zoom'
+        - $ref: '#/parameters/x'
+        - $ref: '#/parameters/y'
+        - $ref: '#/parameters/token'
+        - $ref: '#/parameters/mapToken'
+        - $ref: '#/parameters/redBandOverride'
+        - $ref: '#/parameters/greenBandOverride'
+        - $ref: '#/parameters/blueBandOverride'
+        - $ref: '#/parameters/projectId'
+      responses:
+        200:
+          description: OK
+        401:
+          description: 'Authentication failed -- no authentication methods succeeded'
+        403:
+          description: 'Project does not exist or user is not authorized to view analysis'
+
+  /{projectId}/histogram/:
+    x-resource: Mosaic
+    get:
+      summary: 'Obtain the histogram of this project\'s mosaic'
+      tags:
+        - Mosaic
+      parameters:
+        - $ref: '#/parameters/token'
+        - $ref: '#/parameters/mapToken'
+        - $ref: '#/parameters/redBandOverride'
+        - $ref: '#/parameters/greenBandOverride'
+        - $ref: '#/parameters/blueBandOverride'
+        - $ref: '#/parameters/projectId'
+      responses:
+        200:
+          description: OK
+        401:
+          description: 'Authentication failed -- no authentication methods succeeded'
+        403:
+          description: 'Project does not exist or user is not authorized to view analysis'
+    post:
+      summary: 'Obtain the histogram for this a subset of the scenes in this project\'s mosaic'
+      tags:
+        - Mosaic
+      parameters:
+        - $ref: '#/parameters/token'
+        - $ref: '#/parameters/mapToken'
+        - $ref: '#/parameters/redBandOverride'
+        - $ref: '#/parameters/greenBandOverride'
+        - $ref: '#/parameters/blueBandOverride'
+        - $ref: '#/parameters/projectId'
+        - type: array
+          items:
+            type: string
+            format: uuid
+          in: body
+
+parameters:
+  projectId:
+    name: projectId
+    in: path
+    description: 'ID of the project to visualize'
+    type: string
+    format: uuid
+
+  zoom:
+    name: z
+    in: path
+    description: 'Zoom level for tile visualization'
+    type: integer
+
+  x:
+    name: x
+    in: path
+    description: 'Column for tile visualization'
+    type: integer
+
+  y:
+    name: y
+    in: path
+    description: 'Row for tile visualization'
+    type: integer
+
+  token:
+    name: token
+    in: query
+    description: 'Token to use for authorization'
+    required: false
+
+  mapToken:
+    name: mapToken
+    in: query
+    description: 'Map token to use for authorization'
+    required: false
+
+  redBandOverride:
+    name: redBand
+    in: query
+    description: 'Specific band to use for red if overriding project settings'
+    type: integer
+
+  greenBandOverride:
+    name: greenBand
+    in: query
+    description: 'Specific band to use for green if overriding project settings'
+    type: integer
+
+  blueBandOverride:
+    name: blueBand
+    in: query
+    description: 'Specific band to use for blue if overriding project settings'
+    type: integer


### PR DESCRIPTION
## Overview

This PR includes the tile server spec

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Just keeping up with backsplash for now -- not including full spec in active tile server

## Testing Instructions

 * should be tested by travis if I did that correctly
 * confirm it matches all currently implemented backsplash endpoints
