### PR TITLE
Include missing project fields

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,6 @@ Brief description of what this PR does, and why it is needed.
 ### Checklist
 
 - [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
-- [ ] Both spec files are updated
 
 ### Demo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Removed
 
 ### Fixed
+- Corrected project object definition to include single band and other missing fields [\#63](https://github.com/raster-foundry/raster-foundry-api-spec/pull/63)
 
 ### Security
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -5267,14 +5267,28 @@ definitions:
           items:
             type: string
         extent:
-          type: object
-          description: 'GeoJSON Geometry of project extent'
+          $ref: '#/definitions/ProjectExtent'
         manualOrder:
           type: boolean
           description: 'Is true if project scenes are manually ordered'
         isAOIProject:
           type: boolean
           description: 'Is true if project is an area-of-interest project'
+        aoiCadenceMillis:
+          type: integer
+          format: int64
+        isSingleBand:
+          type: boolean
+          description: 'Whether to apply single band visualization to this project'
+        singleBandOptions:
+          $ref: '#/definitions/SingleBandOptions'
+        defaultAnnotationGroup:
+          type: string
+          format: uuid
+          description: 'Default annotation group new annotations on this project should be linked to'
+          readOnly: true
+        extras:
+          type: object
   Image:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -6280,3 +6294,67 @@ definitions:
         format: uuid
       defaultStyle:
         type: object
+
+  SingleBandOptions:
+    type: object
+    properties:
+      band:
+        type: integer
+        description: 'Which band from scenes in this project to visualize'
+        minimum: 0
+      dataType:
+        type: string
+        description: 'What type of color scheme to use to visualize this project'
+        enum:
+          - DIVERGING
+          - SEQUENTIAL
+          - CATEGORICAL
+      colorBins:
+        type: integer
+        description: |
+          Number of bins to use for continuous color schemes. For example, a value of 255 would assign one
+          value in the color space to each value in the range from 0 to 255. The default value of 0 also uses
+          255 bins. Renders with values between 0 and 255 will have less smooth coloring.
+        maximum: 255
+      colorScheme:
+        $ref: '#/definitions/ColorScheme'
+      legendOrientation:
+        type: string
+        description: 'Unused'
+        enum:
+          - left
+          - right
+      extraNoData:
+        description: 'Additional values to treat as nodata for categorical visualizations. Forthcoming.'
+        type: array
+        items:
+          type: integer
+
+  ProjectExtent:
+    type: object
+    properties:
+      type:
+        type: string
+        description: Geometry type of project
+        enum:
+          - Polygon
+      coordinates:
+        type: array
+        items:
+          type: array
+          items:
+            type: array
+            items:
+              type: number
+              format: float
+            minItems: 2
+            maxItems: 2
+          minItems: 1
+          maxItems: 1
+
+  ColorScheme:
+    type: array
+    description: 'Colors to blend or categorize values in this visualization over'
+    items:
+      type: string
+      pattern: '^\#([A-Fa-f0-9]{6})$'

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -6317,7 +6317,7 @@ definitions:
           255 bins. Renders with values between 0 and 255 will have less smooth coloring.
         maximum: 255
       colorScheme:
-        $ref: '#/definitions/ColorScheme'
+        type: object
       legendOrientation:
         type: string
         description: 'Unused'
@@ -6351,10 +6351,3 @@ definitions:
             maxItems: 2
           minItems: 1
           maxItems: 1
-
-  ColorScheme:
-    type: array
-    description: 'Colors to blend or categorize values in this visualization over'
-    items:
-      type: string
-      pattern: '^\#([A-Fa-f0-9]{6})$'


### PR DESCRIPTION
## Overview

This PR includes missing project fields in the project definition.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Notes

I was having a bit of trouble getting swagger to let me say that color scheme is either an array of hex colors or an object. Since `oneOf` and `anyOf` were [introduced in OpenAPI 3.0](https://github.com/swagger-api/swagger-editor/issues/1667#issuecomment-364242808), we should consider a technical debt card for upgrading at some point.

## Testing Instructions

 * point the python client to this spec:

```bash
$ RF_API_SPEC_PATH='https://raw.githubusercontent.com/raster-foundry/raster-foundry-api-spec/feature/js/include-all-currently-active-project-fields/spec/spec.yml' ipython
```

 * get a project of yours using the spec:

```python
>>> project_id = 'a uuid for one of your projects'
>>> from rasterfoundry.api import API
>>> client = API(api_token='your api token')
>>> fut = client.client.Imagery.get_projects_projectID(projectID=project_id)
>>> resp = fut.result()
```

- confirm `resp` has everything defined on `Project` in the [Raster Foundry datamodel](https://github.com/raster-foundry/raster-foundry/blob/develop/app-backend/datamodel/src/main/scala/Project.scala#L17-L37)

Closes #62 
