### PR TITLE
Add QP to users/me/roles endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [Unreleased](https://github.com/raster-foundry/raster-foundry-api-spec/tree/develop)
+
+### Added
+
+- Added `withGroupName` query parameter to `/users/me/roles` endpoint [\#70](https://github.com/raster-foundry/raster-foundry-api-spec/pull/70)
+
+### Changed
+
+### Fixed
+
+### Removed
+
+
 ## [1.15.0](https://github.com/raster-foundry/raster-foundry/tree/1.15.0) (2018-11-30)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Added
 
-- Added `withGroupName` query parameter to `/users/me/roles` endpoint [\#70](https://github.com/raster-foundry/raster-foundry-api-spec/pull/70)
-
 ### Changed
+
+- Changed the response data model of `/users/me/roles` endpoint [\#70](https://github.com/raster-foundry/raster-foundry-api-spec/pull/70)
 
 ### Fixed
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -183,15 +183,13 @@ paths:
       summary: "Get a logged-in user's roles"
       tags:
         - Users
-      parameters:
-        - $ref: '#/parameters/withGroupName'
       responses:
         200:
           description: 'Roles found'
           schema:
             type: array
             items:
-              $ref: '#/definitions/UserGroupRole'
+              $ref: '#/definitions/UserGroupRoleWithRelated'
         default:
           description: 'Unexpected error'
           schema:
@@ -4333,12 +4331,6 @@ parameters:
     in: path
     type: string
     required: true
-  withGroupName:
-    name: withGroupName
-    description: 'Additionally return user group roles with platform, organization, team names if set to true'
-    in: query
-    type: boolean
-    default: false
 
 definitions:
   Geometry:
@@ -4998,8 +4990,26 @@ definitions:
           - 'TEAM'
         groupId:
           type: string
-          format: uuid
+          format: uui
+        membershipStatus:
+          type: string
+          enum:
+          - 'REQUESTED'
+          - 'INVITED'
+          - 'APPROVED'
     - $ref: '#/definitions/UserRole'
+  UserGroupRoleWithRelated:
+    type: object
+    allOf:
+    - $ref: '#/definitions/UserGroupRole'
+    - type: object
+      properties:
+        platformName:
+          type: string
+        organizationName:
+          type: string
+        teamName:
+          type: string
   PaginatedResponse:
     type: object
     required:

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -4990,7 +4990,7 @@ definitions:
           - 'TEAM'
         groupId:
           type: string
-          format: uui
+          format: uuid
         membershipStatus:
           type: string
           enum:

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -183,6 +183,8 @@ paths:
       summary: "Get a logged-in user's roles"
       tags:
         - Users
+      parameters:
+        - $ref: '#/parameters/withGroupName'
       responses:
         200:
           description: 'Roles found'
@@ -483,7 +485,7 @@ paths:
       summary: 'Get a list of teams that the user can see on the platform.'
       tags:
         - Admin
-      parameters: 
+      parameters:
         - $ref: '#/parameters/platformID'
         - $ref: '#/parameters/search'
       responses:
@@ -4331,6 +4333,12 @@ parameters:
     in: path
     type: string
     required: true
+  withGroupName:
+    name: withGroupName
+    description: 'Additionally return user group roles with platform, organization, team names if set to true'
+    in: query
+    type: boolean
+    default: false
 
 definitions:
   Geometry:


### PR DESCRIPTION
## Overview

This PR adds a query parameter `withGroupName` to `users/me/roles` endpoint.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Confirm it matches the API

