### PR TITLE
Update return of user roles endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- Changed the response data model of `/users/me/roles` endpoint [\#70](https://github.com/raster-foundry/raster-foundry-api-spec/pull/70)
+- Changed the response data model of `/users/me/roles` endpoint [\#70](https://github.com/raster-foundry/raster-foundry-api-spec/pull/70) & [\#72](https://github.com/raster-foundry/raster-foundry-api-spec/pull/72) 
 
 ### Fixed
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -5004,11 +5004,7 @@ definitions:
     - $ref: '#/definitions/UserGroupRole'
     - type: object
       properties:
-        platformName:
-          type: string
-        organizationName:
-          type: string
-        teamName:
+        groupName:
           type: string
   PaginatedResponse:
     type: object


### PR DESCRIPTION
## Overview

This PR updates the spec to reflect the change in the return of `users/me/roles` endpoint so that it now only includes one `groupName` property.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Swagger editor should not complain
 * It should match the changes in [this PR](https://github.com/raster-foundry/raster-foundry/pull/4375)
