### PR TITLE
Add `analysisId` query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,15 @@
 
 ### Added
 
+- Added the `analysisId` query param to endpoints that require authorization via analyses [\#73](https://github.com/raster-foundry/raster-foundry-api-spec/pull/73)
+
 ### Changed
 
-- Changed the response data model of `/users/me/roles` endpoint [\#70](https://github.com/raster-foundry/raster-foundry-api-spec/pull/70) & [\#72](https://github.com/raster-foundry/raster-foundry-api-spec/pull/72) 
+- Changed the response data model of `/users/me/roles` endpoint [\#70](https://github.com/raster-foundry/raster-foundry-api-spec/pull/70) & [\#72](https://github.com/raster-foundry/raster-foundry-api-spec/pull/72)
 
 ### Fixed
 
 ### Removed
-
 
 ## [1.15.0](https://github.com/raster-foundry/raster-foundry/tree/1.15.0) (2018-11-30)
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -1471,6 +1471,7 @@ paths:
         - Imagery
       parameters:
         - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/analysisId'
       responses:
         200:
           description: 'Project found'
@@ -1539,6 +1540,7 @@ paths:
         - Imagery
       parameters:
         - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/analysisId'
       responses:
         200:
           description: 'A list of datasources'
@@ -3767,6 +3769,14 @@ paths:
 
 
 parameters:
+  analysisId:
+    name: analysisId
+    in: query
+    description:
+      | UUID for analysis to use as a request\'s authorization context
+    type: string
+    format: uuid
+    required: false
   groupType:
     name: groupType
     in: query

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -3772,8 +3772,8 @@ parameters:
   analysisId:
     name: analysisId
     in: query
-    description:
-      | UUID for analysis to use as a request\'s authorization context
+    description: |
+      UUID for analysis to use as a request\'s authorization context
     type: string
     format: uuid
     required: false


### PR DESCRIPTION
## Overview

Adds the `analysisId` query parameter to the `GET projects/{projectId}` and `GET projects/{projectId}/datasources` endpoints to allow authorization via an analysis

Pairs with https://github.com/raster-foundry/raster-foundry/pull/4401

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible