### PR TITLE
Add defaultLayerId field to project data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added the `analysisId` query param to endpoints that require authorization via analyses [\#73](https://github.com/raster-foundry/raster-foundry-api-spec/pull/73)
+- Added an optional `defaultLayerId` field to `Project` data model [\#78](https://github.com/raster-foundry/raster-foundry-api-spec/pull/78)
 
 ### Changed
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -5526,7 +5526,7 @@ definitions:
           datasource:
             type: string
             format: uuid
-          
+
   Scene:
     allOf:
       - $ref: '#/definitions/SceneBase'
@@ -5764,6 +5764,10 @@ definitions:
         extras:
           type: object
           description: 'Optional additional json metadata'
+        defaultLayerId:
+          type: string
+          format: uuid
+          description: 'Default project layer id for scenes to add to'
 
   ImageBase:
     allOf:

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -5767,7 +5767,7 @@ definitions:
         defaultLayerId:
           type: string
           format: uuid
-          description: 'Default project layer id for scenes to add to'
+          description: 'Default project layer to interact with'
 
   ImageBase:
     allOf:


### PR DESCRIPTION
## Overview

This PR adds a `defaultLayerId` field to the `Project` data model.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible


## Testing Instructions

 * Swagger editor should not complain
 * It should match the change in https://github.com/raster-foundry/raster-foundry/pull/4479
