### PR TITLE
Include required elements in image properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 - Audited Scene api spec and updated spec to reflect current endpoints [\#76](https://github.com/raster-foundry/raster-foundry-api-spec/pull/76)
+- Included required image fields in image properties [\#79](https://github.com/raster-foundry/raster-foundry-api-spec/pull/79)
 
 ### Security
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -5834,6 +5834,12 @@ definitions:
           description: 'list of band types for image; a single band denotes a single band image, multiple bands should be listed in order (e.g if it is an RGB tiff then bands should be [red, green blue])'
           items:
             $ref: '#/definitions/Band'
+        filename:
+          type: string
+          description: 'The basename of the file holding this image'
+        sourceUri:
+          type: string
+          description: 'An absolute location for accessing this image somewhere in the universe'
 
   ImageWithDownloadUri:
     allOf:


### PR DESCRIPTION
## Overview

This PR includes some items from `required` in a `properties` list in the `Image` definition. Apparently it's important to describe what your required things are. Apparently. No idea why ci isn't mad at us about this, but bravado gets angry over in python client land.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * I couldn't actually get this to fail locally, but lambda hates it 
