### PR TITLE
Add project layer ID tool run list query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added the `analysisId` query param to endpoints that require authorization via analyses [\#73](https://github.com/raster-foundry/raster-foundry-api-spec/pull/73)
 - Added an optional `defaultLayerId` field to `Project` data model [\#78](https://github.com/raster-foundry/raster-foundry-api-spec/pull/78)
 - Added spec for project layer mosaic definition and scene order [\#82](https://github.com/raster-foundry/raster-foundry-api-spec/pull/82)
+- Added project layer ID and changed tool -> template in list endpoint for tool runs [\#83](https://github.com/raster-foundry/raster-foundry-api-spec/pull/83)
 
 ### Changed
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -3182,7 +3182,8 @@ paths:
         - $ref: '#/parameters/pageSize'
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/project'
-        - $ref: '#/parameters/tool'
+        - $ref: '#/parameters/template'
+        - $ref: '#/parameters/projectLayer'
         - $ref: '#/parameters/owner'
         - $ref: '#/parameters/createdBy'
         - $ref: '#/parameters/ownershipType'
@@ -4464,9 +4465,16 @@ parameters:
     in: query
     type: boolean
     required: false
-  tool:
-    name: toolId
-    description: "Filter by tool's slug label"
+  template:
+    name: templateId
+    description: "Filter by template this analysis was created from"
+    in: query
+    type: string
+    format: uuid
+    required: false
+  projectLayer:
+    name: projectLayerId
+    description: "Filter by project layer this analysis was created with"
     in: query
     type: string
     format: uuid


### PR DESCRIPTION
## Overview

This PR adds project layer to the tool run list endpoint query parameters and renames `tool` -> `template` in the same endpoint.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible