### PR TITLE
Add spec for a QP in annotation shapefile export endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added the `analysisId` query param to endpoints that require authorization via analyses [\#73](https://github.com/raster-foundry/raster-foundry-api-spec/pull/73)
 - Added an optional `defaultLayerId` field to `Project` data model [\#78](https://github.com/raster-foundry/raster-foundry-api-spec/pull/78)
 - Added spec for project layer mosaic definition and scene order [\#82](https://github.com/raster-foundry/raster-foundry-api-spec/pull/82)
+- Added spec for a QP in annotation shapefile export endpoint [\#84](https://github.com/raster-foundry/raster-foundry-api-spec/pull/84)
 
 ### Changed
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -1838,6 +1838,7 @@ paths:
         - Imagery
       parameters:
         - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/exportAll'
       responses:
         200:
           description: 'Annotations retrieved successfully'
@@ -4390,6 +4391,12 @@ parameters:
     description: 'Full text search string'
     in: query
     type: string
+    required: false
+  exportAll:
+    name: exportAll
+    description: 'Export all annotations from a project'
+    in: query
+    type: boolean
     required: false
   minRawDataBytes:
     name: minRawDataBytes


### PR DESCRIPTION
## Overview

This PR adds spec for the boolean query parameter `exportAll` in the project annotation shapefile export endpoint.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Make sure that it matches the changes in https://github.com/raster-foundry/raster-foundry/pull/4558