### PR TITLE
Add spec for layer annotation related endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added an optional `defaultLayerId` field to `Project` data model [\#78](https://github.com/raster-foundry/raster-foundry-api-spec/pull/78)
 - Added spec for project layer mosaic definition and scene order [\#82](https://github.com/raster-foundry/raster-foundry-api-spec/pull/82)
 - Added spec for a QP in annotation shapefile export endpoint [\#84](https://github.com/raster-foundry/raster-foundry-api-spec/pull/84)
+- Added spec for layer annotation related endpoints [\#85](https://github.com/raster-foundry/raster-foundry-api-spec/pull/85)
 
 ### Changed
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -1597,7 +1597,7 @@ paths:
   /projects/{projectID}/labels/:
     x-resource: Projects
     get:
-      summary: 'Get a list of the labels used on a project default layer
+      summary: 'Get a list of the labels used on a project default layer'
       tags:
         - Imagery
       parameters:
@@ -2669,7 +2669,57 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /projects/{projectID}/layers/{layerID}/annotations/{annotationID}:
+  /projects/{projectID}/layers/{layerID}/annotations/shapefile:
+    x-resource: Projects
+    get:
+      summary: 'Get a url for project layer annotations exported to a shapefile'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - $ref: '#/parameters/exportAll'
+      responses:
+        200:
+          description: 'Annotations retrieved successfully'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: 'Import annotations from a shapefile to project layer'
+      tags:
+        - Imagery
+      consumes:
+        - multipart/form-data
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - in: formData
+          name: name
+          type: file
+          description: The shapefile to upload
+      responses:
+        201:
+          description: 'Annotations imported successfully'
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/AnnotationFeature'
+        400:
+          description: 'Some records could not be parsed to annotations'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
+  /projects/{projectID}/layers/{layerID}/annotations/{annotationID}/:
     x-resouce: Projects
     get:
       summary: 'Get an annotation belonging to a project layer'
@@ -2735,55 +2785,6 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
-
-    /projects/{projectID}/layers/{layerID}/annotations/shapefile:
-      x-resource: Projects
-      get:
-        summary: 'Get a url for project layer annotations exported to a shapefile'
-        tags:
-          - Imagery
-        parameters:
-          - $ref: '#/parameters/projectID'
-          - $ref: '#/parameters/layerID'
-        responses:
-          200:
-            description: 'Annotations retrieved successfully'
-          403:
-            description: 'Insufficient permissions for resource or resource does not exist'
-            schema:
-              $ref: '#/definitions/Error'
-          default:
-            description: 'Unexpected error'
-            schema:
-              $ref: '#/definitions/Error'
-      post:
-        summary: 'Import annotations from a shapefile to project layer'
-        tags:
-          - Imagery
-        consumes:
-          - multipart/form-data
-        parameters:
-          - $ref: '#/parameters/projectID'
-          - $ref: '#/parameters/layerID'
-          - in: formData
-            name: name
-            type: file
-            description: The shapefile to upload
-        responses:
-          201:
-            description: 'Annotations imported successfully'
-            schema:
-              type: array
-              items:
-                $ref: '#/definitions/AnnotationFeature'
-          400:
-            description: 'Some records could not be parsed to annotations'
-            schema:
-              $ref: '#/definitions/Error'
-          default:
-            description: 'Unexpected error'
-            schema:
-              $ref: '#/definitions/Error'
 
   /projects/{projectID}/layers/{layerID}/annotation-groups/:
     x-resource: Projects

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -1597,7 +1597,7 @@ paths:
   /projects/{projectID}/labels/:
     x-resource: Projects
     get:
-      summary: 'Get a list of the labels used on a project'
+      summary: 'Get a list of the labels used on a project default layer
       tags:
         - Imagery
       parameters:
@@ -1620,14 +1620,14 @@ paths:
   /projects/{projectID}/annotation-groups/:
     x-resource: Projects
     get:
-      summary: 'Get annotation groups belonging to a project'
+      summary: 'Get annotation groups belonging to a project default layer'
       tags:
         - Imagery
       parameters:
         - $ref: '#/parameters/projectID'
       responses:
         200:
-          description: 'Array containing annotation groups for this project'
+          description: 'Array containing annotation groups for this project default layer'
           schema:
             type: array
             items:
@@ -1645,7 +1645,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: 'Create annotation group for this project'
+      summary: 'Create annotation group for this project default layer'
       tags:
         - Imagery
       parameters:
@@ -1671,7 +1671,7 @@ paths:
   /projects/{projectID}/annotation-groups/summary/:
     x-resource: Projects
     get:
-      summary: 'Get a summary of the label groups on a project'
+      summary: 'Get a summary of the label groups on a project default layer'
       tags:
         - Imagery
       parameters:
@@ -1695,7 +1695,7 @@ paths:
   /projects/{projectID}/annotation-groups/{annotationGroupID}/:
     x-resource: Projects
     get:
-      summary: 'Get annotation group for project'
+      summary: 'Get annotation group for project default layer'
       tags:
         - Imagery
       parameters:
@@ -1741,7 +1741,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: 'Delete annotation group and all associated annotations'
+      summary: 'Delete annotation group from project default layer and all associated annotations'
       tags:
         - Imagery
       parameters:
@@ -1765,7 +1765,7 @@ paths:
   /projects/{projectID}/annotations/:
     x-resource: Projects
     get:
-      summary: 'Get annotations belonging to a project'
+      summary: 'Get annotations belonging to a project default layer'
       tags:
         - Imagery
       parameters:
@@ -1776,7 +1776,7 @@ paths:
         - $ref: '#/parameters/pageSize'
       responses:
         200:
-          description: 'GeoJSON feature collection containing paginated annotations of this project'
+          description: 'GeoJSON feature collection containing paginated annotations of this project default layer'
           schema:
             $ref: '#/definitions/AnnotationFeatureCollectionPaginated'
         403:
@@ -1789,7 +1789,7 @@ paths:
             $ref: '#/definitions/Error'
 
     post:
-      summary: 'Create annotations for a project'
+      summary: 'Create annotations for a project default layer'
       tags:
         - Imagery
       parameters:
@@ -1813,7 +1813,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: 'Delete all annotations from a project'
+      summary: 'Delete all annotations from a project default layer'
       tags:
         - Imagery
       parameters:
@@ -1833,7 +1833,7 @@ paths:
   /projects/{projectID}/annotations/shapefile:
     x-resource: Projects
     get:
-      summary: 'Get a url for annotations exported to a shapefile'
+      summary: 'Get a url for project default layer annotations exported to a shapefile'
       tags:
         - Imagery
       parameters:
@@ -1852,7 +1852,7 @@ paths:
             $ref: '#/definitions/Error'
 
     post:
-      summary: 'Import annotations from a shapefile'
+      summary: 'Import annotations from a shapefile to project default layer'
       tags:
         - Imagery
       consumes:
@@ -1883,7 +1883,7 @@ paths:
   /projects/{projectID}/annotations/{annotationID}:
     x-resouce: Projects
     get:
-      summary: 'Get an annotation belonging to a project'
+      summary: 'Get an annotation belonging to a project default layer'
       tags:
         - Imagery
       parameters:
@@ -1891,7 +1891,7 @@ paths:
         - $ref: '#/parameters/annotationID'
       responses:
         200:
-          description: 'GeoJSON feature containing one annotation from this project'
+          description: 'GeoJSON feature containing one annotation from this project default layer'
           schema:
             $ref: '#/definitions/AnnotationFeature'
         403:
@@ -1904,7 +1904,7 @@ paths:
             $ref: '#/definitions/Error'
 
     put:
-      summary: 'Update an annotation of this project'
+      summary: 'Update an annotation of this project default layer'
       tags:
         - Imagery
       parameters:
@@ -1928,7 +1928,7 @@ paths:
             $ref: '#/definitions/Error'
 
     delete:
-      summary: 'Delete an annotation'
+      summary: 'Delete an annotation from project default layer'
       tags:
         - Imagery
       parameters:
@@ -2565,6 +2565,369 @@ paths:
       responses:
         204:
           description: 'Successfully updated order of scenes in the project layer'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
+  /projects/{projectID}/layers/{layerID}/labels:
+    x-resource: Projects
+    get:
+      summary: 'Get a list of labels used on a project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+      responses:
+        200:
+          description: 'A list of labels'
+          schema:
+            type: array
+            items:
+              type: string
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
+  /projects/{projectID}/layers/{layerID}/annotations/:
+    x-resource: Projects
+    get:
+      summary: 'Get annotations belonging to a project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - $ref: '#/parameters/AnnotationLabel'
+        - $ref: '#/parameters/annotationQualityCheck'
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/pageSize'
+      responses:
+        200:
+          description: 'GeoJSON feature collection containing paginated annotations of this project layer'
+          schema:
+            $ref: '#/definitions/AnnotationFeatureCollectionPaginated'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: 'Create annotations for a project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - name: annotations
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/AnnotationFeatureCollectionCreate'
+      responses:
+        201:
+          description: 'GeoJSON annotations successfully created'
+          schema:
+            $ref: '#/definitions/AnnotationFeatureCollection'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: 'Delete all annotations from a project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+      responses:
+        201:
+          description: 'Annotations Deleted'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
+  /projects/{projectID}/layers/{layerID}/annotations/{annotationID}:
+    x-resouce: Projects
+    get:
+      summary: 'Get an annotation belonging to a project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - $ref: '#/parameters/annotationID'
+      responses:
+        200:
+          description: 'GeoJSON feature containing one annotation from this project layer'
+          schema:
+            $ref: '#/definitions/AnnotationFeature'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: 'Update an annotation of this project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - $ref: '#/parameters/annotationID'
+        - name: annotation
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/AnnotationFeatureUpdate'
+      responses:
+        204:
+          description: 'No content, update successful'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: 'Delete an annotation'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - $ref: '#/parameters/annotationID'
+      responses:
+        204:
+          description: 'Deletion successful.'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
+    /projects/{projectID}/layers/{layerID}/annotations/shapefile:
+      x-resource: Projects
+      get:
+        summary: 'Get a url for project layer annotations exported to a shapefile'
+        tags:
+          - Imagery
+        parameters:
+          - $ref: '#/parameters/projectID'
+          - $ref: '#/parameters/layerID'
+        responses:
+          200:
+            description: 'Annotations retrieved successfully'
+          403:
+            description: 'Insufficient permissions for resource or resource does not exist'
+            schema:
+              $ref: '#/definitions/Error'
+          default:
+            description: 'Unexpected error'
+            schema:
+              $ref: '#/definitions/Error'
+      post:
+        summary: 'Import annotations from a shapefile to project layer'
+        tags:
+          - Imagery
+        consumes:
+          - multipart/form-data
+        parameters:
+          - $ref: '#/parameters/projectID'
+          - $ref: '#/parameters/layerID'
+          - in: formData
+            name: name
+            type: file
+            description: The shapefile to upload
+        responses:
+          201:
+            description: 'Annotations imported successfully'
+            schema:
+              type: array
+              items:
+                $ref: '#/definitions/AnnotationFeature'
+          400:
+            description: 'Some records could not be parsed to annotations'
+            schema:
+              $ref: '#/definitions/Error'
+          default:
+            description: 'Unexpected error'
+            schema:
+              $ref: '#/definitions/Error'
+
+  /projects/{projectID}/layers/{layerID}/annotation-groups/:
+    x-resource: Projects
+    get:
+      summary: 'Get annotation groups belonging to a project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+      responses:
+        200:
+          description: 'Array containing annotation groups for this project layer'
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/AnnotationGroup'
+        404:
+          description: 'Resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        403:
+          description: 'Insufficient permissions for resource'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: 'Create annotation group for this project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - name: annotationGroup
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/AnnotationGroupCreate'
+      responses:
+        200:
+          description: 'Created annotation group'
+          schema:
+            $ref: '#/definitions/AnnotationGroup'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
+  /projects/{projectID}/layers/{layerID}/annotation-groups/summary/:
+    x-resource: Projects
+    get:
+      summary: 'Get a summary of the label groups on a project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+      responses:
+        200:
+          description: 'Fetched label summaries'
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/LabelSummary'
+        404:
+          description: 'Resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
+  /projects/{projectID}/layers/{layerID}/annotation-groups/{annotationGroupID}/:
+    x-resource: Projects
+    get:
+      summary: 'Get annotation group for project layer'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - $ref: '#/parameters/annotationGroupID'
+      responses:
+        200:
+          description: 'fetched annotation group'
+          schema:
+            $ref: '#/definitions/AnnotationGroup'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: 'Update annotation group'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - $ref: '#/parameters/annotationGroupID'
+        - name: annotationGroup
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/AnnotationGroup'
+      responses:
+        200:
+          description: 'Number of updated annotation groups from this request'
+          schema:
+            type: number
+            format: integer
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: 'Delete annotation group from project layer and all associated annotations'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - $ref: '#/parameters/annotationGroupID'
+      responses:
+        200:
+          description: 'Number of deleted annotation groups from this request'
+          schema:
+            type: number
+            format: integer
         403:
           description: 'Insufficient permissions for resource or resource does not exist'
           schema:


### PR DESCRIPTION
## Overview

This PR adds spec for the below endpoints:
- CRUD Layer Annotations 
- CRUD Layer Annotation Groups
- Export Layer Annotation Shapefile
- Import Layer Annotation Shapefile
- List Annotation Labels for Layer

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible


## Testing Instructions

 * Make sure they match endpoints changed in https://github.com/raster-foundry/raster-foundry/pull/4569
