### PR TITLE
Add project layer stats endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added spec for a QP in annotation shapefile export endpoint [\#84](https://github.com/raster-foundry/raster-foundry-api-spec/pull/84)
 - Added spec for layer annotation related endpoints [\#85](https://github.com/raster-foundry/raster-foundry-api-spec/pull/85)
 - Added project layer ID and changed tool -> template in list endpoint for tool runs [\#83](https://github.com/raster-foundry/raster-foundry-api-spec/pull/83)
+- Added project layer stats endpoint [\#88](https://github.com/raster-foundry/raster-foundry-api-spec/pull/88)
 
 ### Changed
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -2444,6 +2444,28 @@ paths:
                 - 'ANNOTATE'
                 - '*'
 
+  /projects/{projectID}/layers/stats:
+    x-resource: Projects
+    get:
+      summary: "Count scenes in each layer of this project"
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+      responses:
+        200:
+          description: 'A map of project layer IDs to counts of scenes'
+          schema:
+            type: object
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+
   /projects/{projectID}/layers/{layerID}/mosaic:
     x-resource: Projects
     get:


### PR DESCRIPTION
## Overview

This PR adds the project layer stats endpoint.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * ci
 * check description

See raster-foundry/raster-foundry#4625