### PR TITLE
Add spec for layer QP on export list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added spec for layer annotation related endpoints [\#85](https://github.com/raster-foundry/raster-foundry-api-spec/pull/85)
 - Added project layer ID and changed tool -> template in list endpoint for tool runs [\#83](https://github.com/raster-foundry/raster-foundry-api-spec/pull/83)
 - Added project layer stats endpoint [\#88](https://github.com/raster-foundry/raster-foundry-api-spec/pull/88)
+- Added spec for layer ID QP on export list endpoint [\#90](https://github.com/raster-foundry/raster-foundry-api-spec/pull/90)
 
 ### Changed
 

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -3766,6 +3766,7 @@ paths:
         - $ref: '#/parameters/project'
         - $ref: '#/parameters/owner'
         - $ref: '#/parameters/exportStatus'
+        - $ref: '#/parameters/layer'
       responses:
         200:
           description: 'Paginated list of exports'
@@ -4836,6 +4837,13 @@ parameters:
   project:
     name: project
     description: 'Project uuid to filter only'
+    in: query
+    type: string
+    format: uuid
+    required: false
+  layer:
+    name: layer
+    description: 'Project layer uuid to filter only'
     in: query
     type: string
     format: uuid


### PR DESCRIPTION
## Overview

This PR adds spec for `layer` QP on export list endpoint.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible


## Testing Instructions

 * Make sure it matches https://github.com/raster-foundry/raster-foundry/pull/4663
