### PR TITLE
Add singleSource query param to tools list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added project layer stats endpoint [\#88](https://github.com/raster-foundry/raster-foundry-api-spec/pull/88)
 - Added project analyses endpoint [\#89](https://github.com/raster-foundry/raster-foundry-api-spec/pull/89)
 - Added spec for layer ID QP on export list endpoint [\#90](https://github.com/raster-foundry/raster-foundry-api-spec/pull/90)
+- Added query parameter for whether templates can sensibly be run with a single project layer [\#92](https://github.com/raster-foundry/raster-foundry-api-spec/pull/92)
 
 ### Changed
 - Change owner qp to array type [/#91](https://github.com/raster-foundry/raster-foundry-api-spec/pull/91)

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -3458,6 +3458,7 @@ paths:
         - $ref: '#/parameters/ownershipType'
         - $ref: '#/parameters/groupType'
         - $ref: '#/parameters/groupId'
+        - $ref: '#/parameters/singleSource'
       responses:
         200:
           description: 'Returns a paginated list of tools'
@@ -4548,6 +4549,12 @@ parameters:
     in: query
     description: 'Filter by color group hex'
     type: string
+  singleSource:
+    name: singleSource
+    in: query
+    description: |
+      Whether a template can be sensibly filled in using a single project layer
+    type: boolean
     required: false
   analysisId:
     name: analysisId


### PR DESCRIPTION
## Overview

This PR adds the `singleSource` query parameter to the `/tools/` list endpoint to match raster-foundry/raster-foundry#4701.
 
### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible