### PR TITLE
Add single band options to ProjectLayers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added project analyses endpoint [\#89](https://github.com/raster-foundry/raster-foundry-api-spec/pull/89)
 - Added spec for layer ID QP on export list endpoint [\#90](https://github.com/raster-foundry/raster-foundry-api-spec/pull/90)
 - Added query parameter for whether templates can sensibly be run with a single project layer [\#92](https://github.com/raster-foundry/raster-foundry-api-spec/pull/92)
+- Added single band options to project layers [\#93](https://github.com/raster-foundry/raster-foundry-api-spec/pull/93)
 
 ### Changed
 - Change owner qp to array type [/#91](https://github.com/raster-foundry/raster-foundry-api-spec/pull/91)

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -5220,6 +5220,11 @@ definitions:
           type: string
           format: datetime
           description: End date for scene matching when associated with a smart layer
+        isSingleBand:
+          type: boolean
+          description: 'Use single band options to render instead of bands'
+        singleBandOptions:
+          $ref: '#/definitions/SingleBandOptions'
 
   ProjectLayerPaginated:
     type: object


### PR DESCRIPTION
## Overview

This PR adds single band options to project layers, consistent with changes in raster-foundry/raster-foundry#4712

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * ci