### PR TITLE
Add projectId and layerId QP to upload list endpoint spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@
 - Added query parameter for whether templates can sensibly be run with a single project layer [\#92](https://github.com/raster-foundry/raster-foundry-api-spec/pull/92)
 - Added single band options to project layers [\#93](https://github.com/raster-foundry/raster-foundry-api-spec/pull/93)
 - Added query parameter for filtering layer shape [\#94](https://github.com/raster-foundry/raster-foundry-api-spec/pull/94)
-- Add split layer endpoint and datamodels [\#95](https://github.com/raster-foundry/raster-foundry-api-spec/pull/95)
+- Added split layer endpoint and datamodels [\#95](https://github.com/raster-foundry/raster-foundry-api-spec/pull/95)
 - Added layerId parameter to api/scenes, clarified existing project params [\#87](https://github.com/raster-foundry/raster-foundry-api-spec/pull/87)
 - Added map token query parameter support for annotation listing [\#98](https://github.com/raster-foundry/raster-foundry-api-spec/pull/98)
+- Added layerId and projectId query parameters to uploads list endpoint [\#99](https://github.com/raster-foundry/raster-foundry-api-spec/pull/99)
 
 ### Changed
 - Change owner qp to array type [/#91](https://github.com/raster-foundry/raster-foundry-api-spec/pull/91)

--- a/spec/spec.yml
+++ b/spec/spec.yml
@@ -988,6 +988,8 @@ paths:
         - $ref: '#/parameters/datasource'
         - $ref: '#/parameters/uploadStatus'
         - $ref: '#/parameters/owner'
+        - $ref: '#/parameters/projectId'
+        - $ref: '#/parameters/layerId'
       responses:
         200:
           description: 'Paginated list of uploads'
@@ -4596,6 +4598,12 @@ parameters:
     name: projectId
     in: query
     description: 'UUID for project'
+    type: string
+    format: uuid
+  layerId:
+    name: layerId
+    in: query
+    description: 'UUID for a project layer'
     type: string
     format: uuid
   queryAuthToken:


### PR DESCRIPTION
## Overview

This PR adds `projectId` and `layerId` query parameters to upload list endpoint's spec.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry-api-spec/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Make sure CI is not mad
 * Make sure it matches the changes in commit `cfe8586` in https://github.com/raster-foundry/raster-foundry/pull/4809
